### PR TITLE
Specified peerDependecies in shared packages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,7 +198,7 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       eslint:
-        specifier: ^9.9.1
+        specifier: ^9
         version: 9.9.1
       eslint-config-prettier:
         specifier: ^9.1.0
@@ -206,14 +206,17 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.1
         version: 2.30.0(@typescript-eslint/parser@8.4.0(eslint@9.9.1)(typescript@5.5.4))(eslint@9.9.1)
+      typescript:
+        specifier: ^5
+        version: 5.5.4
       typescript-eslint:
         specifier: ^8.0.1
         version: 8.4.0(eslint@9.9.1)(typescript@5.5.4)
 
   shared/prettier:
-    devDependencies:
+    dependencies:
       prettier:
-        specifier: ^3.3.3
+        specifier: ^3
         version: 3.3.3
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - packages/**
   - shared/**
+  - examples/**

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,3 @@
 packages:
   - packages/**
   - shared/**
-  - examples/**

--- a/shared/eslint/package.json
+++ b/shared/eslint/package.json
@@ -7,9 +7,12 @@
   },
   "dependencies": {
     "@eslint/compat": "^1.1.1",
-    "eslint": "^9.9.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
     "typescript-eslint": "^8.0.1"
+  },
+  "peerDependencies": {
+    "eslint": "^9",
+    "typescript": "^5"
   }
 }

--- a/shared/prettier/package.json
+++ b/shared/prettier/package.json
@@ -5,7 +5,7 @@
   "exports": {
     ".": "./index.js"
   },
-  "devDependencies": {
-    "prettier": "^3.3.3"
+  "peerDependencies": {
+    "prettier": "^3"
   }
 }


### PR DESCRIPTION
Shared packages are aimed to be used with devDeps in other packages, so prettier/eslint should just be a peerDep.