### PR TITLE
Revert accidentally updated packages to fix tests

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,7 +150,7 @@ importers:
         version: 2.4.4
       '@types/node':
         specifier: ^20.14.10
-        version: 22.7.5
+        version: 20.16.11
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.11
@@ -223,7 +223,7 @@ importers:
         version: 14.5.2(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: ^20.14.10
-        version: 22.7.5
+        version: 20.16.11
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.11
@@ -232,13 +232,13 @@ importers:
         version: 18.3.0
       '@vitejs/plugin-react':
         specifier: ^4.3.1
-        version: 4.3.2(vite@5.4.6(@types/node@22.7.5))
+        version: 4.3.2(vite@5.4.6(@types/node@20.16.11))
       eslint:
         specifier: ^9.6.0
         version: 9.12.0
       happy-dom:
         specifier: ^14.12.3
-        version: 15.7.4
+        version: 14.12.3
       msw:
         specifier: ^2.4.9
         version: 2.4.9(typescript@5.6.3)
@@ -253,10 +253,10 @@ importers:
         version: 5.6.3
       vite-tsconfig-paths:
         specifier: ^4.3.2
-        version: 5.0.1(typescript@5.6.3)(vite@5.4.6(@types/node@22.7.5))
+        version: 4.3.2(typescript@5.6.3)(vite@5.4.6(@types/node@20.16.11))
       vitest:
         specifier: ^2.0.3
-        version: 2.1.2(@types/node@22.7.5)(happy-dom@15.7.4)(msw@2.4.9(typescript@5.6.3))
+        version: 2.1.2(@types/node@20.16.11)(happy-dom@14.12.3)(msw@2.4.9(typescript@5.6.3))
 
   packages/graphql-config:
     dependencies:
@@ -272,7 +272,7 @@ importers:
         version: link:../../shared/prettier
       '@types/node':
         specifier: ^20.14.10
-        version: 22.7.5
+        version: 20.16.11
       eslint:
         specifier: ^9.6.0
         version: 9.12.0
@@ -299,7 +299,7 @@ importers:
         version: 9.1.0(eslint@9.12.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.31.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint@9.12.0)
+        version: 2.31.0(eslint@9.12.0)
       typescript:
         specifier: ^5
         version: 5.6.3
@@ -1370,6 +1370,9 @@ packages:
   '@types/node-fetch@2.6.11':
     resolution: {integrity: sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==}
 
+  '@types/node@20.16.11':
+    resolution: {integrity: sha512-y+cTCACu92FyA5fgQSAI8A1H429g7aSK2HsO7K4XYUWc4dY5IUz55JSDIYT6/VsOLfGy8vmvQYC2hfb0iF16Uw==}
+
   '@types/node@22.7.5':
     resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
@@ -2276,9 +2279,9 @@ packages:
     resolution: {integrity: sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  happy-dom@15.7.4:
-    resolution: {integrity: sha512-r1vadDYGMtsHAAsqhDuk4IpPvr6N8MGKy5ntBo7tSdim+pWDxus2PNqOcOt8LuDZ4t3KJHE+gCuzupcx/GKnyQ==}
-    engines: {node: '>=18.0.0'}
+  happy-dom@14.12.3:
+    resolution: {integrity: sha512-vsYlEs3E9gLwA1Hp+w3qzu+RUDFf4VTT8cyKqVICoZ2k7WM++Qyd2LwzyTi5bqMJFiIC/vNpTDYuxdreENRK/g==}
+    engines: {node: '>=16.0.0'}
 
   has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
@@ -3507,8 +3510,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite-tsconfig-paths@5.0.1:
-    resolution: {integrity: sha512-yqwv+LstU7NwPeNqajZzLEBVpUFU6Dugtb2P84FXuvaoYA+/70l9MHE+GYfYAycVyPSDYZ7mjOFuYBRqlEpTig==}
+  vite-tsconfig-paths@4.3.2:
+    resolution: {integrity: sha512-0Vd/a6po6Q+86rPlntHye7F31zA2URZMbH8M3saAZ/xR9QoGN/L21bxEGfXdWmFdNkqPpRdxFT7nmNe12e9/uA==}
     peerDependencies:
       vite: '*'
     peerDependenciesMeta:
@@ -4657,13 +4660,13 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
 
   '@types/chroma-js@2.4.4': {}
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
 
   '@types/cookie@0.6.0': {}
 
@@ -4673,7 +4676,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.5':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
       '@types/qs': 6.9.16
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -4703,12 +4706,16 @@ snapshots:
 
   '@types/mute-stream@0.0.4':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
 
   '@types/node-fetch@2.6.11':
     dependencies:
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
       form-data: 4.0.0
+
+  '@types/node@20.16.11':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/node@22.7.5':
     dependencies:
@@ -4738,12 +4745,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
       '@types/send': 0.17.4
 
   '@types/statuses@2.0.5': {}
@@ -4840,14 +4847,14 @@ snapshots:
     transitivePeerDependencies:
       - graphql
 
-  '@vitejs/plugin-react@4.3.2(vite@5.4.6(@types/node@22.7.5))':
+  '@vitejs/plugin-react@4.3.2(vite@5.4.6(@types/node@20.16.11))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.25.2)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.25.2)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.6(@types/node@22.7.5)
+      vite: 5.4.6(@types/node@20.16.11)
     transitivePeerDependencies:
       - supports-color
 
@@ -4869,14 +4876,14 @@ snapshots:
       chai: 5.1.1
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(msw@2.4.9(typescript@5.6.3))(vite@5.4.6(@types/node@22.7.5))':
+  '@vitest/mocker@2.1.2(@vitest/spy@2.1.2)(msw@2.4.9(typescript@5.6.3))(vite@5.4.6(@types/node@20.16.11))':
     dependencies:
       '@vitest/spy': 2.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.11
     optionalDependencies:
       msw: 2.4.9(typescript@5.6.3)
-      vite: 5.4.6(@types/node@22.7.5)
+      vite: 5.4.6(@types/node@20.16.11)
 
   '@vitest/pretty-format@2.1.2':
     dependencies:
@@ -5511,17 +5518,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.12.0):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.12.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.8.1(eslint@9.12.0)(typescript@5.6.3)
       eslint: 9.12.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint@9.12.0):
+  eslint-plugin-import@2.31.0(eslint@9.12.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5532,7 +5538,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.12.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.12.0)
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.12.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -5543,8 +5549,6 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.8.1(eslint@9.12.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -5869,7 +5873,7 @@ snapshots:
 
   graphql@16.9.0: {}
 
-  happy-dom@15.7.4:
+  happy-dom@14.12.3:
     dependencies:
       entities: 4.5.0
       webidl-conversions: 7.0.0
@@ -7059,12 +7063,12 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@2.1.2(@types/node@22.7.5):
+  vite-node@2.1.2(@types/node@20.16.11):
     dependencies:
       cac: 6.7.14
       debug: 4.3.6
       pathe: 1.1.2
-      vite: 5.4.6(@types/node@22.7.5)
+      vite: 5.4.6(@types/node@20.16.11)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -7076,24 +7080,24 @@ snapshots:
       - supports-color
       - terser
 
-  vite-tsconfig-paths@5.0.1(typescript@5.6.3)(vite@5.4.6(@types/node@22.7.5)):
+  vite-tsconfig-paths@4.3.2(typescript@5.6.3)(vite@5.4.6(@types/node@20.16.11)):
     dependencies:
-      debug: 4.3.6
+      debug: 4.3.7
       globrex: 0.1.2
       tsconfck: 3.1.3(typescript@5.6.3)
     optionalDependencies:
-      vite: 5.4.6(@types/node@22.7.5)
+      vite: 5.4.6(@types/node@20.16.11)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@5.4.6(@types/node@22.7.5):
+  vite@5.4.6(@types/node@20.16.11):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.45
       rollup: 4.21.2
     optionalDependencies:
-      '@types/node': 22.7.5
+      '@types/node': 20.16.11
       fsevents: 2.3.3
 
   vite@5.4.8(@types/node@22.7.5):
@@ -7105,10 +7109,10 @@ snapshots:
       '@types/node': 22.7.5
       fsevents: 2.3.3
 
-  vitest@2.1.2(@types/node@22.7.5)(happy-dom@15.7.4)(msw@2.4.9(typescript@5.6.3)):
+  vitest@2.1.2(@types/node@20.16.11)(happy-dom@14.12.3)(msw@2.4.9(typescript@5.6.3)):
     dependencies:
       '@vitest/expect': 2.1.2
-      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.4.9(typescript@5.6.3))(vite@5.4.6(@types/node@22.7.5))
+      '@vitest/mocker': 2.1.2(@vitest/spy@2.1.2)(msw@2.4.9(typescript@5.6.3))(vite@5.4.6(@types/node@20.16.11))
       '@vitest/pretty-format': 2.1.2
       '@vitest/runner': 2.1.2
       '@vitest/snapshot': 2.1.2
@@ -7123,12 +7127,12 @@ snapshots:
       tinyexec: 0.3.0
       tinypool: 1.0.1
       tinyrainbow: 1.2.0
-      vite: 5.4.6(@types/node@22.7.5)
-      vite-node: 2.1.2(@types/node@22.7.5)
+      vite: 5.4.6(@types/node@20.16.11)
+      vite-node: 2.1.2(@types/node@20.16.11)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 22.7.5
-      happy-dom: 15.7.4
+      '@types/node': 20.16.11
+      happy-dom: 14.12.3
     transitivePeerDependencies:
       - less
       - lightningcss


### PR DESCRIPTION
Currently, tests for fabrix on main branch is failing with this error:

```
Error: R] "vite-tsconfig-paths" resolved to an ESM file. ESM file cannot be loaded by `require`. See https://vitejs.dev/guide/troubleshooting.html#this-package-is-esm-only for more details. [plugin externalize-deps]

    ../../node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1225:27:
      1225 │         let result = await callback({
           ╵                            ^

    at file:///home/runner/work/fabrix/fabrix/node_modules/.pnpm/vite@5.4.6_@types+node@22.7.5/node_modules/vite/dist/node/chunks/dep-DyBnyoVI.js:66586:23
    at requestCallbacks.on-resolve (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1225:28)
    at handleRequest (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:647:17)
    at handleIncomingPacket (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:672:7)
    at Socket.readFromStdout (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:600:7)
    at Socket.emit (node:events:517:28)
    at addChunk (node:internal/streams/readable:368:12)
    at readableAddChunk (node:internal/streams/readable:341:9)
    at Readable.push (node:internal/streams/readable:278:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23)

  This error came from the "onResolve" callback registered here:

    ../../node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1150:20:
      1150 │       let promise = setup({
           ╵                     ^

    at setup (file:///home/runner/work/fabrix/fabrix/node_modules/.pnpm/vite@5.4.6_@types+node@22.7.5/node_modules/vite/dist/node/chunks/dep-DyBnyoVI.js:66548:18)
    at handlePlugins (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1150:21)
    at buildOrContextImpl (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:873:5)
    at Object.buildOrContext (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:699:5)
    at /home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:2023:15
    at new Promise (<anonymous>)
    at Object.build (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:2022:25)
    at build (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1873:51)
    at bundleConfigFile (file:///home/runner/work/fabrix/fabrix/node_modules/.pnpm/vite@5.4.6_@types+node@22.7.5/node_modules/vite/dist/node/chunks/dep-DyBnyoVI.js:66503:24)

  The plugin "externalize-deps" was triggered by this import

    vitest.config.ts:2:26:
      2 │ import tsconfigPaths from "vite-tsconfig-paths";
        ╵                           ~~~~~~~~~~~~~~~~~~~~~

failed to load config from /home/runner/work/fabrix/fabrix/packages/fabrix/vitest.config.ts

⎯⎯⎯⎯⎯⎯⎯ Startup Error ⎯⎯⎯⎯⎯⎯⎯⎯
Error: Build failed with 1 error:
../../node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1225:27: ERROR: [plugin: externalize-deps] "vite-tsconfig-paths" resolved to an ESM file. ESM file cannot be loaded by `require`. See https://vitejs.dev/guide/troubleshooting.html#this-package-is-esm-only for more details.
    at failureErrorWithLog (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1472:15)
    at /home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:[94](https://github.com/fabrix-framework/fabrix/actions/runs/11269022995/job/31336831531#step:4:101)5:25
    at runOnEndCallbacks (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:1315:45)
    at buildResponseToResult (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:943:7)
    at /home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:[97](https://github.com/fabrix-framework/fabrix/actions/runs/11269022995/job/31336831531#step:4:104)0:16
    at responseCallbacks.<computed> (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:622:9)
    at handleIncomingPacket (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:677:12)
    at Socket.readFromStdout (/home/runner/work/fabrix/fabrix/node_modules/.pnpm/esbuild@0.21.5/node_modules/esbuild/lib/main.js:600:7)
    at Socket.emit (node:events:517:28)
    at addChunk (node:internal/streams/readable:368:12) {
  errors: [Getter/Setter],
  warnings: [Getter/Setter]
}
```

This is caused by  #19 that I have added unintentionally version upgrades for packages that I didn't to expect. 

Within these changes, `vitest-tsconfig-paths` was also updated to v5 and now it only provides an ESM package that makes our tests fail. This PR downgrades those unwanted package updates.