### PR TITLE
Split packages by node.js dependencies

### DIFF
--- a/packages/graphql-config/package.json
+++ b/packages/graphql-config/package.json
@@ -3,8 +3,16 @@
   "private": false,
   "version": "0.1.0",
   "description": "GraphQL configuration for fabrix",
-  "main": "dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
+    },
+    "./schema": {
+      "types": "./dist/schema.d.mts",
+      "default": "./dist/schema.mjs"
+    }
+  },
   "files": [
     "dist/**"
   ],

--- a/packages/graphql-config/src/config.ts
+++ b/packages/graphql-config/src/config.ts
@@ -1,10 +1,8 @@
 import * as os from "node:os";
 import * as path from "node:path";
 import * as fs from "node:fs";
-import { parse } from "graphql";
 import Document from "./directive.graphql";
 
-export const schemaDefinition = parse(Document);
 export const generateConfig = () => {
   const tempGQLFile = path.join(os.tmpdir(), "fabrix-graphql-config.graphql");
 

--- a/packages/graphql-config/src/index.ts
+++ b/packages/graphql-config/src/index.ts
@@ -1,1 +1,1 @@
-export { generateConfig, schemaDefinition } from "./config";
+export { generateConfig } from "./config";

--- a/packages/graphql-config/src/schema.ts
+++ b/packages/graphql-config/src/schema.ts
@@ -1,0 +1,4 @@
+import { parse } from "graphql";
+import Document from "./directive.graphql";
+
+export const schemaDefinition = parse(Document);

--- a/packages/graphql-config/tsup.config.ts
+++ b/packages/graphql-config/tsup.config.ts
@@ -12,7 +12,7 @@ const devOpts =
 
 export default defineConfig({
   format: ["esm"],
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/schema.ts"],
   clean: true,
   minify: true,
   dts: true,


### PR DESCRIPTION
Importing `@fabrix-framework/graphql-config` automatically imports Node.js related dependencies (e.g. `node:os`, `node:path`, ...), so this PR splits the packages by Node.js dependencies.

This is critical that the client components in Next.js app cannot import `graphql-config` packages due to its dependencies.