### PR TITLE
Add a job to publish preview packages

### DIFF
--- a/.github/workflows/ci-packages.yaml
+++ b/.github/workflows/ci-packages.yaml
@@ -43,3 +43,26 @@ jobs:
       - uses: ./.github/actions/build
         with:
           filter: "examples/*"
+
+  # Once all jobs are successful, publish the packages
+  publish-preview:
+    needs:
+      - ci
+      - build-examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.9.0
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          cache-dependency-path: ./pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install
+      - name: Build
+        run: pnpm build
+      - run: pnpx pkg-pr-new publish "./packages/*"


### PR DESCRIPTION
We are actively developing fabrix, so I would like to use [pkg-pr-new](https://github.com/stackblitz-labs/pkg.pr.new) for faster development iteration.

pkg-pr-new is now only working on Github Action (it cannot be used locally), so this PR adds it in our CI.