### PR TITLE
Give defaultValues and handle number inputs for react-hook-form

### DIFF
--- a/packages/chakra-ui/src/components/default/form.tsx
+++ b/packages/chakra-ui/src/components/default/form.tsx
@@ -3,7 +3,7 @@ import {
   FormComponentProps,
   FieldType,
 } from "@fabrix-framework/fabrix";
-import { Switch, Input, Stack, Button, Box } from "@chakra-ui/react";
+import { Switch, Input, Stack, Button, Box, Text } from "@chakra-ui/react";
 import { Select } from "chakra-react-select";
 import { useController } from "@fabrix-framework/fabrix/rhf";
 import { LabelledHeading } from "./shared";

--- a/packages/chakra-ui/src/components/default/form.tsx
+++ b/packages/chakra-ui/src/components/default/form.tsx
@@ -55,6 +55,21 @@ export const ChakraFormField = (props: FormFieldComponentProps) => {
   }
 };
 
+const ErrorField = (props: FormFieldComponentProps) => {
+  const { formState } = useController({
+    name: props.name,
+  });
+  const error = formState.errors[props.name];
+
+  return (
+    error && (
+      <Text color="red.500" size="sm" role="alert">
+        {error?.message?.toString()}
+      </Text>
+    )
+  );
+};
+
 type EnumFieldType = Extract<FieldType, { type: "Enum" }>;
 
 const MultiSelectFormField = (
@@ -114,6 +129,7 @@ const TextFormField = (props: FormFieldComponentProps) => {
   const { attributes } = props;
   const { field } = useController({
     name: props.name,
+    defaultValue: props.value ?? "",
   });
 
   return (
@@ -128,12 +144,21 @@ const NumberFormField = (props: FormFieldComponentProps) => {
   const { className } = props.attributes;
   const { field } = useController({
     name: props.name,
+    defaultValue: props.value ?? "",
   });
 
   return (
     <Stack className={className} spacing={2}>
       <LabelledHeading {...props} />
-      <Input {...field} type="number" placeholder="Enter value" />
+      <Input
+        {...field}
+        type="number"
+        placeholder="Enter value"
+        onChange={(e) => {
+          field.onChange(parseFloat(e.target.value));
+        }}
+      />
+      <ErrorField {...props} />
     </Stack>
   );
 };

--- a/packages/chakra-ui/src/components/default/shared.tsx
+++ b/packages/chakra-ui/src/components/default/shared.tsx
@@ -11,7 +11,7 @@ export const LabelledHeading = (
   const { attributes } = props;
 
   return (
-    <Flex gap={2}>
+    <Flex gap={2} as="label" htmlFor={props.name}>
       <Heading size="xs">{attributes.label}</Heading>
       {isRequired && (
         <Badge colorScheme="red" fontSize="xs">


### PR DESCRIPTION
This is a PR that has changes to fix two bugs:

* Fix #9: this bug is caused by missing of data conversion for sending values to RHF through `onChange`, so this PR added data conversion for String to Number.
* Fix #48: giving an initial value has been needed to make controlled components.