### PR TITLE
Specify nodejs version on ci

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -16,6 +16,7 @@ runs:
       with:
         cache: pnpm
         cache-dependency-path: ./pnpm-lock.yaml
+        node-version-file: './package.json'
     - name: Install dependencies
       run: pnpm install
       shell: bash

--- a/.github/actions/ci/action.yaml
+++ b/.github/actions/ci/action.yaml
@@ -17,6 +17,7 @@ runs:
       with:
         cache: pnpm
         cache-dependency-path: ./pnpm-lock.yaml
+        node-version-file: './package.json'
     - name: Install dependencies
       run: pnpm install
       shell: bash

--- a/.github/workflows/ci-packages.yaml
+++ b/.github/workflows/ci-packages.yaml
@@ -61,6 +61,7 @@ jobs:
         with:
           cache: pnpm
           cache-dependency-path: ./pnpm-lock.yaml
+          node-version-file: './package.json'
       - name: Install dependencies
         run: pnpm install
       - name: Build


### PR DESCRIPTION
Remove: `WARN  Unsupported engine: wanted: {"node":"22.x"} (current: {"node":"v18.20.4","pnpm":"9.9.0"})`