### PR TITLE
Preparation to support fragment spread

### DIFF
--- a/packages/fabrix/src/directive/schema.ts
+++ b/packages/fabrix/src/directive/schema.ts
@@ -1,5 +1,5 @@
 import { fallbackDefault } from "@directive/zod";
-import { Path } from "@visitor";
+import { Path } from "@visitor/path";
 import { z } from "zod";
 
 const defaultValues = {

--- a/packages/fabrix/src/readers/field.ts
+++ b/packages/fabrix/src/readers/field.ts
@@ -1,6 +1,6 @@
 import { viewFieldSchema } from "@directive/schema";
 import { FieldConfigWithMeta, FieldConfig } from "@readers/shared";
-import { Fields } from "@visitor";
+import { Fields } from "@visitor/fields";
 import { deepmerge } from "deepmerge-ts";
 
 /**

--- a/packages/fabrix/src/readers/form.ts
+++ b/packages/fabrix/src/readers/form.ts
@@ -5,7 +5,8 @@ import {
   formFieldSchema,
 } from "@directive/schema";
 import { resolveFieldType } from "@renderers/shared";
-import { FieldVariables, Path } from "@visitor";
+import { FieldVariables } from "@visitor";
+import { Path } from "@visitor/path";
 import { deepmerge } from "deepmerge-ts";
 import {
   GraphQLInputObjectType,

--- a/packages/fabrix/src/readers/shared.ts
+++ b/packages/fabrix/src/readers/shared.ts
@@ -1,5 +1,5 @@
 import { FieldType } from "@renderers/shared";
-import { Path } from "@visitor";
+import { Path } from "@visitor/path";
 
 type FieldMeta = {
   fieldType: FieldType;

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -13,7 +13,8 @@ import { directiveSchemaMap } from "@directive/schema";
 import { mergeFieldConfigs } from "@readers/shared";
 import { buildDefaultViewFieldConfigs, viewFieldMerger } from "@readers/field";
 import { buildDefaultFormFieldConfigs, formFieldMerger } from "@readers/form";
-import { buildRootDocument, Field, Fields, FieldVariables } from "@/visitor";
+import { buildRootDocument, FieldVariables } from "@/visitor";
+import { Field, Fields } from "@/visitor/fields";
 import { FabrixComponentData } from "@/fetcher";
 
 const decideStrategy = (

--- a/packages/fabrix/src/visitor.test.ts
+++ b/packages/fabrix/src/visitor.test.ts
@@ -1,0 +1,74 @@
+import { buildRootDocument } from "@visitor";
+import { gql } from "urql";
+import { describe, expect, test } from "vitest";
+
+describe("buildRootDocument", () => {
+  test("should build root document", () => {
+    const documents = buildRootDocument(gql`
+      query getUser {
+        user {
+          id
+          name
+        }
+      }
+    `);
+
+    expect(documents.length).toBe(1);
+    expect(
+      documents[0].fields
+        .getChildrenWithAncestors("user")
+        .unwrap()
+        .map((f) => f.getName()),
+    ).toStrictEqual(["id", "name"]);
+  });
+
+  test("should build root document with multiple operations", () => {
+    const documents = buildRootDocument(gql`
+      query getUser {
+        user {
+          userName
+        }
+      }
+
+      mutation getRole {
+        role {
+          roleName
+        }
+      }
+    `);
+
+    expect(documents.length).toBe(2);
+    expect(
+      documents[0].fields
+        .getChildrenWithAncestors("user")
+        .unwrap()
+        .map((f) => f.getName()),
+    ).toStrictEqual(["userName"]);
+    expect(
+      documents[1].fields
+        .getChildrenWithAncestors("role")
+        .unwrap()
+        .map((f) => f.getName()),
+    ).toStrictEqual(["roleName"]);
+  });
+
+  test("should build root document with a fragment spread", () => {
+    const documents = buildRootDocument(gql`
+      query getUser {
+        user {
+          id
+          name
+          ...userProfileImage
+        }
+      }
+    `);
+
+    expect(documents.length).toBe(1);
+    expect(
+      documents[0].fields
+        .getChildrenWithAncestors("user")
+        .unwrap()
+        .map((f) => f.getName()),
+    ).toStrictEqual(["id", "name", "userProfileImage"]);
+  });
+});

--- a/packages/fabrix/src/visitor.ts
+++ b/packages/fabrix/src/visitor.ts
@@ -1,3 +1,4 @@
+import { Path } from "@visitor/path";
 import {
   DirectiveNode,
   DocumentNode,
@@ -9,93 +10,6 @@ import {
   ValueNode,
   visit,
 } from "graphql";
-
-export class Path {
-  constructor(
-    /**
-     * The path value as an array of strings.
-     */
-    readonly value: string[] = [],
-  ) {}
-
-  /**
-   * Convert the path to a string key with the given delimiter (Default is ".")
-   *
-   * Example:
-   *
-   * ```ts
-   * const path = new Path(["a", "b", "c"]);
-   * path.asKey(); // "a.b.c"
-   * ```
-   */
-  asKey(delimiter = ".") {
-    return this.value.join(delimiter);
-  }
-
-  /**
-   * Get the last element of the path.
-   *
-   * Example:
-   *
-   * ```ts
-   * const path = new Path(["a", "b", "c"]);
-   * path.getName(); // "c"
-   * ```
-   */
-  getName() {
-    return this.value[this.value.length - 1];
-  }
-
-  /**
-   * Get the parent path of the current path.
-   * If the path is empty, it will return undefined.
-   *
-   * Example:
-   *
-   * ```ts
-   * const path = new Path(["a", "b", "c"]);
-   * path.getParent(); // Path(["a", "b"])
-   * ```
-   */
-  getParent() {
-    if (this.value.length === 0) {
-      return;
-    }
-
-    return new Path(this.value.slice(0, this.value.length - 1));
-  }
-
-  /**
-   * Get the level of the path
-   *
-   * The level is the number of elements in the path.
-   */
-  getLevel() {
-    return this.value.length;
-  }
-
-  /**
-   * Append a path to the current path.
-   */
-  append(path: Path | string) {
-    return new Path([
-      ...this.value,
-      ...(path instanceof Path ? path.value : [path]),
-    ]);
-  }
-
-  /**
-   * Get the path instance with the root offset by the given start index.
-   */
-  rootOffset(start: number) {
-    const sliced = this.value.slice(start);
-    if (sliced.length === 0) {
-      return null;
-    }
-
-    return new Path(sliced);
-  }
-}
 
 type SubField = {
   name: string;

--- a/packages/fabrix/src/visitor.ts
+++ b/packages/fabrix/src/visitor.ts
@@ -1,4 +1,4 @@
-import { Path } from "@visitor/path";
+import { Fields } from "@visitor/fields";
 import {
   DirectiveNode,
   DocumentNode,
@@ -10,102 +10,6 @@ import {
   ValueNode,
   visit,
 } from "graphql";
-
-type SubField = {
-  name: string;
-  path: Path;
-};
-
-type FieldConstructorProps = {
-  fields: Array<SubField>;
-  path: Path;
-  directives: ReadonlyArray<DirectiveNode>;
-};
-
-export class Field {
-  constructor(readonly value: FieldConstructorProps) {}
-
-  getName() {
-    return this.value.path.getName();
-  }
-
-  getParentName() {
-    return this.value.path.getParent()?.getName();
-  }
-
-  getLevel() {
-    return this.value.path.getLevel();
-  }
-}
-
-type AddFieldProps = {
-  name: string;
-  fields: Array<string>;
-  directives: ReadonlyArray<DirectiveNode>;
-};
-
-export class Fields {
-  constructor(private value: Array<Field> = []) {}
-
-  add(props: AddFieldProps) {
-    const path = this.buildPath(props.name);
-    this.value.push(
-      new Field({
-        path,
-        fields: props.fields.map((f) => ({
-          name: f,
-          path: path.append(f),
-        })),
-        directives: props.directives,
-      }),
-    );
-  }
-
-  getChildren(parentName: string) {
-    return new Fields(
-      this.value.filter((f) => f.getParentName() === parentName),
-    );
-  }
-
-  getChildrenWithAncestors(parentName: string) {
-    const getChildrenRecursively = (parentName: string): Array<Field> => {
-      const children = this.getChildren(parentName);
-      return children.unwrap().length > 0
-        ? children
-            .unwrap()
-            .flatMap((f) => [f, ...getChildrenRecursively(f.getName())])
-        : [];
-    };
-
-    return new Fields(getChildrenRecursively(parentName));
-  }
-
-  getParent(childName: string) {
-    return this.value.find((f) =>
-      f.value.fields.map((f) => f.name).includes(childName),
-    );
-  }
-
-  getByPathKey(key: string) {
-    return this.value.find((f) => f.value.path.asKey() === key);
-  }
-
-  unwrap() {
-    return this.value;
-  }
-
-  /**
-   * Recursively build the path key for a field
-   */
-  private buildPath(name: string, acc: string[] = []): Path {
-    const parent = this.getParent(name);
-    if (parent) {
-      return this.buildPath(parent.getName(), [name, ...acc]);
-    }
-
-    return new Path([name, ...acc]);
-  }
-}
 
 export type FieldVariables = Record<
   string,

--- a/packages/fabrix/src/visitor/fields.test.ts
+++ b/packages/fabrix/src/visitor/fields.test.ts
@@ -6,7 +6,16 @@ describe("Fields", () => {
 
   fields.add({
     name: "a",
-    fields: ["b", "c"],
+    fields: [
+      {
+        type: "field",
+        name: "b",
+      },
+      {
+        type: "field",
+        name: "c",
+      },
+    ],
     directives: [],
   });
   fields.add({
@@ -17,7 +26,16 @@ describe("Fields", () => {
 
   fields.add({
     name: "c",
-    fields: ["d", "e"],
+    fields: [
+      {
+        type: "field",
+        name: "d",
+      },
+      {
+        type: "field",
+        name: "e",
+      },
+    ],
     directives: [],
   });
   fields.add({

--- a/packages/fabrix/src/visitor/fields.test.ts
+++ b/packages/fabrix/src/visitor/fields.test.ts
@@ -1,0 +1,67 @@
+import { describe, test, expect } from "vitest";
+import { Fields } from "./fields";
+
+describe("Fields", () => {
+  const fields = new Fields([]);
+
+  fields.add({
+    name: "a",
+    fields: ["b", "c"],
+    directives: [],
+  });
+  fields.add({
+    name: "b",
+    fields: [],
+    directives: [],
+  });
+
+  fields.add({
+    name: "c",
+    fields: ["d", "e"],
+    directives: [],
+  });
+  fields.add({
+    name: "d",
+    fields: [],
+    directives: [],
+  });
+  fields.add({
+    name: "e",
+    fields: [],
+    directives: [],
+  });
+
+  test.each(["a.b", "a.c", "a.c.d", "a.c.e"])(
+    "getByPathKey (%s) should not be undefined",
+    (pathKey) => {
+      expect(fields.getByPathKey(pathKey)).not.toBeUndefined();
+    },
+  );
+
+  test("getChildren should return all children", () => {
+    expect(fields.getChildren("a").unwrap().length).toBe(2);
+  });
+
+  test("getChildrenWithAncestors should return all children with ancestors", () => {
+    expect(fields.getChildrenWithAncestors("a").unwrap().length).toBe(4);
+  });
+
+  test.each([
+    ["b", "a"],
+    ["c", "a"],
+    ["d", "c"],
+    ["e", "c"],
+    ["a", undefined],
+  ])("getParent of '%s' should be '%s'", (child, parent) => {
+    expect(fields.getParent(child)?.getName()).toBe(parent);
+  });
+
+  test.each([
+    ["a.b", "a"],
+    ["a.c", "a"],
+    ["a.c.d", "c"],
+    ["a.c.e", "c"],
+  ])("getParent of '%s' should be '%s'", (child, parent) => {
+    expect(fields.getByPathKey(child)?.getParentName()).toBe(parent);
+  });
+});

--- a/packages/fabrix/src/visitor/fields.ts
+++ b/packages/fabrix/src/visitor/fields.ts
@@ -2,6 +2,7 @@ import { DirectiveNode } from "graphql";
 import { Path } from "./path";
 
 type SubField = {
+  type: "field" | "fragment";
   name: string;
   path: Path;
 };
@@ -28,9 +29,11 @@ export class Field {
   }
 }
 
+export type SelectionField = Omit<SubField, "path">;
+
 type AddFieldProps = {
   name: string;
-  fields: Array<string>;
+  fields: Array<SelectionField>;
   directives: ReadonlyArray<DirectiveNode>;
 };
 
@@ -43,8 +46,9 @@ export class Fields {
       new Field({
         path,
         fields: props.fields.map((f) => ({
-          name: f,
-          path: path.append(f),
+          type: f.type,
+          name: f.name,
+          path: path.append(f.name),
         })),
         directives: props.directives,
       }),

--- a/packages/fabrix/src/visitor/fields.ts
+++ b/packages/fabrix/src/visitor/fields.ts
@@ -1,0 +1,98 @@
+import { DirectiveNode } from "graphql";
+import { Path } from "./path";
+
+type SubField = {
+  name: string;
+  path: Path;
+};
+
+type FieldConstructorProps = {
+  fields: Array<SubField>;
+  path: Path;
+  directives: ReadonlyArray<DirectiveNode>;
+};
+
+export class Field {
+  constructor(readonly value: FieldConstructorProps) {}
+
+  getName() {
+    return this.value.path.getName();
+  }
+
+  getParentName() {
+    return this.value.path.getParent()?.getName();
+  }
+
+  getLevel() {
+    return this.value.path.getLevel();
+  }
+}
+
+type AddFieldProps = {
+  name: string;
+  fields: Array<string>;
+  directives: ReadonlyArray<DirectiveNode>;
+};
+
+export class Fields {
+  constructor(private value: Array<Field> = []) {}
+
+  add(props: AddFieldProps) {
+    const path = this.buildPath(props.name);
+    this.value.push(
+      new Field({
+        path,
+        fields: props.fields.map((f) => ({
+          name: f,
+          path: path.append(f),
+        })),
+        directives: props.directives,
+      }),
+    );
+  }
+
+  getChildren(parentName: string) {
+    return new Fields(
+      this.value.filter((f) => f.getParentName() === parentName),
+    );
+  }
+
+  getChildrenWithAncestors(parentName: string) {
+    const getChildrenRecursively = (parentName: string): Array<Field> => {
+      const children = this.getChildren(parentName);
+      return children.unwrap().length > 0
+        ? children
+            .unwrap()
+            .flatMap((f) => [f, ...getChildrenRecursively(f.getName())])
+        : [];
+    };
+
+    return new Fields(getChildrenRecursively(parentName));
+  }
+
+  getParent(childName: string) {
+    return this.value.find((f) =>
+      f.value.fields.map((f) => f.name).includes(childName),
+    );
+  }
+
+  getByPathKey(key: string) {
+    return this.value.find((f) => f.value.path.asKey() === key);
+  }
+
+  unwrap() {
+    return this.value;
+  }
+
+  /**
+   * Recursively build the path key for a field
+   */
+  private buildPath(name: string, acc: string[] = []): Path {
+    const parent = this.getParent(name);
+    if (parent) {
+      return this.buildPath(parent.getName(), [name, ...acc]);
+    }
+
+    return new Path([name, ...acc]);
+  }
+}

--- a/packages/fabrix/src/visitor/path.ts
+++ b/packages/fabrix/src/visitor/path.ts
@@ -1,0 +1,86 @@
+export class Path {
+  constructor(
+    /**
+     * The path value as an array of strings.
+     */
+    readonly value: string[] = [],
+  ) {}
+
+  /**
+   * Convert the path to a string key with the given delimiter (Default is ".")
+   *
+   * Example:
+   *
+   * ```ts
+   * const path = new Path(["a", "b", "c"]);
+   * path.asKey(); // "a.b.c"
+   * ```
+   */
+  asKey(delimiter = ".") {
+    return this.value.join(delimiter);
+  }
+
+  /**
+   * Get the last element of the path.
+   *
+   * Example:
+   *
+   * ```ts
+   * const path = new Path(["a", "b", "c"]);
+   * path.getName(); // "c"
+   * ```
+   */
+  getName() {
+    return this.value[this.value.length - 1];
+  }
+
+  /**
+   * Get the parent path of the current path.
+   * If the path is empty, it will return undefined.
+   *
+   * Example:
+   *
+   * ```ts
+   * const path = new Path(["a", "b", "c"]);
+   * path.getParent(); // Path(["a", "b"])
+   * ```
+   */
+  getParent() {
+    if (this.value.length === 0) {
+      return;
+    }
+
+    return new Path(this.value.slice(0, this.value.length - 1));
+  }
+
+  /**
+   * Get the level of the path
+   *
+   * The level is the number of elements in the path.
+   */
+  getLevel() {
+    return this.value.length;
+  }
+
+  /**
+   * Append a path to the current path.
+   */
+  append(path: Path | string) {
+    return new Path([
+      ...this.value,
+      ...(path instanceof Path ? path.value : [path]),
+    ]);
+  }
+
+  /**
+   * Get the path instance with the root offset by the given start index.
+   */
+  rootOffset(start: number) {
+    const sliced = this.value.slice(start);
+    if (sliced.length === 0) {
+      return null;
+    }
+
+    return new Path(sliced);
+  }
+}

--- a/packages/fabrix/vitest.config.ts
+++ b/packages/fabrix/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [viteReact(), tsconfigPaths()],
   test: {
-    include: ["src/**/*.test.tsx", "__tests__/**/*.test.tsx"],
+    include: ["src/**/*.test.(tsx|ts)", "__tests__/**/*.test.(tsx|ts)"],
     environment: "happy-dom",
     setupFiles: ["./__tests__/setup.ts"],
   },


### PR DESCRIPTION
As preparation before working on #37, add support for fragment spread in GQL AST visitor.

Plus, moved some classes defined all together in `visitor.ts` into another files, and added unit tests for future changes.