### PR TITLE
fix buildRootDocument for nested fields

### DIFF
--- a/packages/fabrix/src/registry.tsx
+++ b/packages/fabrix/src/registry.tsx
@@ -30,6 +30,7 @@ export type Field = {
 export type FieldComponentProps<P extends UserProps = UserProps> =
   BaseComponentProps &
     CustomRendererProps<P> & {
+      path: string[];
       subFields: Array<Field>;
     };
 

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -134,7 +134,7 @@ const useFieldConfigs = (query: DocumentNode | string) => {
     return rootDocument.map(({ document, fields, opType, variables }) =>
       fields
         .unwrap()
-        .filter((f) => !f.getParentName())
+        .filter((f) => f.value.path.value.length === 2)
         .reduce<FieldConfigs>((acc, field) => {
           const fieldConfig = getFieldConfig(
             context,

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -134,7 +134,7 @@ const useFieldConfigs = (query: DocumentNode | string) => {
     return rootDocument.map(({ document, fields, opType, variables }) =>
       fields
         .unwrap()
-        .filter((f) => f.value.path.value.length === 2)
+        .filter((f) => !f.getParentName())
         .reduce<FieldConfigs>((acc, field) => {
           const fieldConfig = getFieldConfig(
             context,

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -314,6 +314,7 @@ const renderField = (
   return createElement(component, {
     key: props.indexKey,
     name: field.field.asKey(),
+    path: field.field.value,
     value: values?.[fieldName] ?? "-",
     type: fieldType,
     subFields: subFields.map((subField) => ({

--- a/packages/fabrix/src/visitor.test.ts
+++ b/packages/fabrix/src/visitor.test.ts
@@ -62,6 +62,7 @@ describe("buildRootDocument", () => {
           director {
             name
           }
+          name
         }
       }
     `);
@@ -77,6 +78,7 @@ describe("buildRootDocument", () => {
       "movie.producer.name",
       "movie.director",
       "movie.director.name",
+      "movie.name",
     ]);
   });
 

--- a/packages/fabrix/src/visitor.test.ts
+++ b/packages/fabrix/src/visitor.test.ts
@@ -52,6 +52,34 @@ describe("buildRootDocument", () => {
     ).toStrictEqual(["roleName"]);
   });
 
+  test("should build root document with nested fields", () => {
+    const documents = buildRootDocument(gql`
+      query getMovie {
+        movie {
+          producer {
+            name
+          }
+          director {
+            name
+          }
+        }
+      }
+    `);
+
+    expect(documents.length).toBe(1);
+    expect(
+      documents[0].fields
+        .getChildrenWithAncestors("movie")
+        .unwrap()
+        .map((f) => f.value.path.value.join(".")),
+    ).toStrictEqual([
+      "movie.producer",
+      "movie.producer.name",
+      "movie.director",
+      "movie.director.name",
+    ]);
+  });
+
   test("should build root document with a fragment spread", () => {
     const documents = buildRootDocument(gql`
       query getUser {

--- a/packages/fabrix/src/visitor/fields.test.ts
+++ b/packages/fabrix/src/visitor/fields.test.ts
@@ -70,16 +70,6 @@ describe("Fields", () => {
   });
 
   test.each([
-    ["b", "a"],
-    ["c", "a"],
-    ["d", "c"],
-    ["e", "c"],
-    ["a", undefined],
-  ])("getParent of '%s' should be '%s'", (child, parent) => {
-    expect(fields.getParent(child)?.getName()).toBe(parent);
-  });
-
-  test.each([
     ["a.b", "a"],
     ["a.c", "a"],
     ["a.c.d", "c"],

--- a/packages/fabrix/src/visitor/fields.test.ts
+++ b/packages/fabrix/src/visitor/fields.test.ts
@@ -17,11 +17,13 @@ describe("Fields", () => {
       },
     ],
     directives: [],
+    path: ["a"],
   });
   fields.add({
     name: "b",
     fields: [],
     directives: [],
+    path: ["a", "b"],
   });
 
   fields.add({
@@ -37,16 +39,19 @@ describe("Fields", () => {
       },
     ],
     directives: [],
+    path: ["a", "c"],
   });
   fields.add({
     name: "d",
     fields: [],
     directives: [],
+    path: ["a", "c", "d"],
   });
   fields.add({
     name: "e",
     fields: [],
     directives: [],
+    path: ["a", "c", "e"],
   });
 
   test.each(["a.b", "a.c", "a.c.d", "a.c.e"])(

--- a/packages/fabrix/src/visitor/fields.ts
+++ b/packages/fabrix/src/visitor/fields.ts
@@ -75,9 +75,9 @@ export class Fields {
   }
 
   getParent(childName: string) {
-    return this.value.find((f) =>
-      f.value.fields.map((f) => f.name).includes(childName),
-    );
+    return Array.from(this.value)
+      .reverse()
+      .find((f) => f.value.fields.map((f) => f.name).includes(childName));
   }
 
   getByPathKey(key: string) {

--- a/packages/fabrix/src/visitor/fields.ts
+++ b/packages/fabrix/src/visitor/fields.ts
@@ -75,12 +75,6 @@ export class Fields {
     return new Fields(getChildrenRecursively(parentName));
   }
 
-  getParent(childName: string) {
-    return Array.from(this.value)
-      .reverse()
-      .find((f) => f.value.fields.map((f) => f.name).includes(childName));
-  }
-
   getByPathKey(key: string) {
     return this.value.find((f) => f.value.path.asKey() === key);
   }

--- a/packages/fabrix/src/visitor/fields.ts
+++ b/packages/fabrix/src/visitor/fields.ts
@@ -35,13 +35,14 @@ type AddFieldProps = {
   name: string;
   fields: Array<SelectionField>;
   directives: ReadonlyArray<DirectiveNode>;
+  path: string[];
 };
 
 export class Fields {
   constructor(private value: Array<Field> = []) {}
 
   add(props: AddFieldProps) {
-    const path = this.buildPath(props.name);
+    const path = new Path(props.path);
     this.value.push(
       new Field({
         path,
@@ -86,17 +87,5 @@ export class Fields {
 
   unwrap() {
     return this.value;
-  }
-
-  /**
-   * Recursively build the path key for a field
-   */
-  private buildPath(name: string, acc: string[] = []): Path {
-    const parent = this.getParent(name);
-    if (parent) {
-      return this.buildPath(parent.getName(), [name, ...acc]);
-    }
-
-    return new Path([name, ...acc]);
   }
 }


### PR DESCRIPTION
### Bug

`buildRootDocument` returns wrong value for operation with nested fields.

```gql
query getMovie {
   movie {
     producer {
      name
    }
    director {
      name
    }
  }
}
```

#### ASIS
```json
[
  "movie.producer",
  "movie.producer.name",
  "movie.director",
  "movie.producer.name", // wrong
]
```

#### TOBE
```json
[
  "movie.producer",
  "movie.producer.name",
  "movie.director",
  "movie.director.name", // correct
]
```
