### PR TITLE
Remove table header

### DIFF
--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -255,12 +255,8 @@ const renderTable = (
     return <div>WARN: Relay style table renderer is not supported for now</div>;
   };
 
-  const headerConfig = getFieldConfigByKey(fields, "collection");
   return (
     <div className={"fabrix table"}>
-      {headerConfig && (
-        <h2 className={"fabrix table-title"}>{headerConfig.config.label}</h2>
-      )}
       {tableMode === "standard" ? renderStandardTable() : renderRelayTable()}
     </div>
   );


### PR DESCRIPTION
Table header should not automatically rendered by fabrix. 

It should focus on rendering table component itself for flexible usecase.