### PR TITLE
ComponentFunc return type:  ReactElement -> ReactNode

### DIFF
--- a/packages/fabrix/src/registry.tsx
+++ b/packages/fabrix/src/registry.tsx
@@ -85,7 +85,7 @@ export type FormComponentProps<P extends UserProps = UserProps> =
 
 type ComponentFunc<P> = (
   props: React.PropsWithChildren<P>,
-) => React.ReactElement;
+) => React.ReactNode;
 
 type CustomComponent =
   | {


### PR DESCRIPTION
Allow ComponentFunc to return null