### PR TITLE
Simplify renderer strategy decision

### DIFF
--- a/packages/fabrix/src/directive.ts
+++ b/packages/fabrix/src/directive.ts
@@ -3,11 +3,17 @@ import { z, ZodRawShape } from "zod";
 import { buildDirectiveConfig, DirectiveConfig } from "@visitor";
 import { directiveSchemaMap } from "@directive/schema";
 
+const emptyArguments = {
+  input: [],
+};
+
 export const parseDirectiveArguments = <S extends ZodRawShape = ZodRawShape>(
-  directiveArguments: DirectiveConfig["arguments"],
+  directiveArguments: DirectiveConfig["arguments"] | null,
   schemaToParse: z.ZodObject<S>,
 ) => {
-  const parsedValue = schemaToParse.safeParse(directiveArguments);
+  const parsedValue = schemaToParse.safeParse(
+    directiveArguments ?? emptyArguments,
+  );
   if (!parsedValue.success) {
     throw new Error(parsedValue.error.message);
   }

--- a/packages/fabrix/src/directive/schema.ts
+++ b/packages/fabrix/src/directive/schema.ts
@@ -1,4 +1,3 @@
-import { fallbackDefault } from "@directive/zod";
 import { Path } from "@visitor/path";
 import { z } from "zod";
 
@@ -13,7 +12,7 @@ export const baseFieldSchema = z.object({
   hidden: z
     .boolean()
     .nullish()
-    .transform(fallbackDefault(defaultValues.hidden)),
+    .transform((v) => v ?? defaultValues.hidden),
   componentType: z
     .object({
       name: z.string().nullish(),
@@ -29,7 +28,7 @@ export const formFieldSchema = baseFieldSchema.merge(
     gridCol: z
       .number()
       .nullish()
-      .transform(fallbackDefault(defaultValues.gridCol)),
+      .transform((v) => v ?? defaultValues.gridCol),
     placeholder: z.string().nullish(),
     defaultValue: z.string().nullish(),
   }),
@@ -60,7 +59,7 @@ export const viewFieldSchema = baseFieldSchema.merge(
     gridCol: z
       .number()
       .nullish()
-      .transform(fallbackDefault(defaultValues.gridCol)),
+      .transform((v) => v ?? defaultValues.gridCol),
   }),
 );
 
@@ -83,10 +82,11 @@ export const directiveSchemaMap = {
             return new Path(value.split("."));
           }),
           config: viewFieldSchema.nullish().transform(
-            fallbackDefault({
-              gridCol: defaultValues.gridCol,
-              hidden: defaultValues.hidden,
-            }),
+            (v) =>
+              v ?? {
+                gridCol: defaultValues.gridCol,
+                hidden: defaultValues.hidden,
+              },
           ),
         }),
       ),
@@ -104,10 +104,11 @@ export const directiveSchemaMap = {
             return new Path(value.split("."));
           }),
           config: formFieldSchema.nullish().transform(
-            fallbackDefault({
-              gridCol: defaultValues.gridCol,
-              hidden: defaultValues.hidden,
-            }),
+            (v) =>
+              v ?? {
+                gridCol: defaultValues.gridCol,
+                hidden: defaultValues.hidden,
+              },
           ),
           constraint: formFieldConstraintSchema,
         }),

--- a/packages/fabrix/src/directive/zod.ts
+++ b/packages/fabrix/src/directive/zod.ts
@@ -1,4 +1,0 @@
-export const fallbackDefault =
-  <T>(defaultValue: T) =>
-  (value: T | null | undefined) =>
-    value ?? defaultValue;

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -22,22 +22,24 @@ const decideStrategy = (
   opType: OperationTypeNode,
 ) => {
   const directive = findDirective(directiveNodes);
+  const emptyDirective = {
+    arguments: null,
+  } as const;
+
   switch (opType) {
     case OperationTypeNode.QUERY: {
-      switch (directive?.name) {
-        case "fabrixView":
-          return { type: "view", directive } as const;
-        default:
-          return { type: "view:no-directive" } as const;
-      }
+      return {
+        type: "view",
+        directive:
+          directive?.name === "fabrixView" ? directive : emptyDirective,
+      } as const;
     }
     case OperationTypeNode.MUTATION: {
-      switch (directive?.name) {
-        case "fabrixForm":
-          return { type: "form", directive } as const;
-        default:
-          return { type: "form:no-directive" } as const;
-      }
+      return {
+        type: "form",
+        directive:
+          directive?.name === "fabrixForm" ? directive : emptyDirective,
+      } as const;
     }
     default: {
       return null;
@@ -77,16 +79,6 @@ const getFieldConfig = (
         },
       };
     }
-    case "view:no-directive": {
-      return {
-        name: field.getName(),
-        type: "view" as const,
-        configs: {
-          fields: buildDefaultViewFieldConfigs(childFields),
-        },
-      };
-    }
-
     case "form": {
       const directive = parseDirectiveArguments(
         strategy.directive.arguments,
@@ -105,22 +97,13 @@ const getFieldConfig = (
         },
       };
     }
-    case "form:no-directive": {
-      return {
-        name: field.getName(),
-        type: "form" as const,
-        configs: {
-          fields: buildDefaultFormFieldConfigs(context, fieldVariables),
-        },
-      };
-    }
     default: {
       return null;
     }
   }
 };
 
-type FieldConfig = ReturnType<typeof getFieldConfig> & {
+export type FieldConfig = ReturnType<typeof getFieldConfig> & {
   document: DocumentNode;
 };
 type FieldConfigs = Record<string, FieldConfig>;

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -12,12 +12,12 @@ import {
   resolveFieldTypesFromTypename,
 } from "./shared";
 
-type ViewRendererFields = FieldConfigByType<"view">["configs"]["fields"];
-type ViewRendererField = ViewRendererFields[number];
+type ViewFields = FieldConfigByType<"view">["configs"]["fields"];
+type ViewField = ViewFields[number];
 
 export const ViewRenderer = (
   props: CommonFabrixComponentRendererProps<{
-    fields: ViewRendererFields;
+    fields: ViewFields;
   }>,
 ) => {
   const { context, fieldConfigs, query, defaultData, componentFieldsRenderer } =
@@ -160,7 +160,7 @@ const getTypeName = (
 const getSubFields = (
   context: FabrixContextType,
   rootValue: Value | undefined,
-  fields: ViewRendererFields,
+  fields: ViewFields,
   name: string,
 ) =>
   // filters fields by parent key and maps the filtered values to the array of SubField
@@ -177,7 +177,7 @@ const getSubFields = (
 const renderTable = (
   context: FabrixContextType,
   rootValue: Value | undefined,
-  fields: ViewRendererFields,
+  fields: ViewFields,
   tableMode: "standard" | "relay",
 ) => {
   if (!rootValue || !("collection" in rootValue)) {
@@ -266,7 +266,7 @@ export type SubField = ReturnType<typeof getSubFields>[number];
 const renderField = (
   props: RendererCommonProps & {
     indexKey: string;
-    field: ViewRendererField;
+    field: ViewField;
     subFields: Array<SubField>;
   },
 ) => {

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -1,6 +1,4 @@
 import { createElement, useCallback, useMemo } from "react";
-import { ViewFieldSchema } from "@directive/schema";
-import { FieldConfigWithMeta } from "@readers/shared";
 import { FabrixContextType } from "@context";
 import { useDataFetch, Value } from "../fetcher";
 import { RendererCommonProps } from "../renderer";
@@ -8,17 +6,18 @@ import {
   assertObjectValue,
   buildClassName,
   CommonFabrixComponentRendererProps,
+  FieldConfigByType,
   getFieldConfigByKey,
   Loader,
   resolveFieldTypesFromTypename,
 } from "./shared";
 
-type ViewField = FieldConfigWithMeta<ViewFieldSchema>;
-type Fields = Array<ViewField>;
+type ViewRendererFields = FieldConfigByType<"view">["configs"]["fields"];
+type ViewRendererField = ViewRendererFields[number];
 
 export const ViewRenderer = (
   props: CommonFabrixComponentRendererProps<{
-    fields: Fields;
+    fields: ViewRendererFields;
   }>,
 ) => {
   const { context, fieldConfigs, query, defaultData, componentFieldsRenderer } =
@@ -161,7 +160,7 @@ const getTypeName = (
 const getSubFields = (
   context: FabrixContextType,
   rootValue: Value | undefined,
-  fields: Fields,
+  fields: ViewRendererFields,
   name: string,
 ) =>
   // filters fields by parent key and maps the filtered values to the array of SubField
@@ -178,7 +177,7 @@ const getSubFields = (
 const renderTable = (
   context: FabrixContextType,
   rootValue: Value | undefined,
-  fields: Fields,
+  fields: ViewRendererFields,
   tableMode: "standard" | "relay",
 ) => {
   if (!rootValue || !("collection" in rootValue)) {
@@ -267,7 +266,7 @@ export type SubField = ReturnType<typeof getSubFields>[number];
 const renderField = (
   props: RendererCommonProps & {
     indexKey: string;
-    field: ViewField;
+    field: ViewRendererField;
     subFields: Array<SubField>;
   },
 ) => {

--- a/packages/fabrix/src/renderers/form.tsx
+++ b/packages/fabrix/src/renderers/form.tsx
@@ -1,25 +1,24 @@
 import { createElement, useCallback } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useMutation } from "urql";
-import { FormFieldSchema } from "@directive/schema";
-import { FieldConfigWithMeta } from "@readers/shared";
-import { FormFieldExtra } from "@readers/form";
 import { FabrixContextType } from "../context";
 import {
   buildClassName,
   CommonFabrixComponentRendererProps,
   defaultFieldType,
+  FieldConfigByType,
   getFieldConfigByKey,
   Loader,
 } from "./shared";
 import { buildAjvSchema } from "./form/validation";
 import { ajvResolver } from "./form/ajvResolver";
 
-export type FormField = FieldConfigWithMeta<FormFieldSchema> & FormFieldExtra;
+export type FormRendererFields = FieldConfigByType<"form">["configs"]["fields"];
+export type FormRendererField = FormRendererFields[number];
 
 export const FormRenderer = (
   props: CommonFabrixComponentRendererProps<{
-    fields: Array<FormField>;
+    fields: FormRendererFields;
   }>,
 ) => {
   const { context, fieldConfigs, query, componentFieldsRenderer } = props;
@@ -95,7 +94,7 @@ export const FormRenderer = (
 
 const renderField = (props: {
   indexKey: string;
-  field: FormField;
+  field: FormRendererField;
   context: FabrixContextType;
   extraClassName?: string;
 }) => {

--- a/packages/fabrix/src/renderers/form.tsx
+++ b/packages/fabrix/src/renderers/form.tsx
@@ -13,12 +13,12 @@ import {
 import { buildAjvSchema } from "./form/validation";
 import { ajvResolver } from "./form/ajvResolver";
 
-export type FormRendererFields = FieldConfigByType<"form">["configs"]["fields"];
-export type FormRendererField = FormRendererFields[number];
+export type FormFields = FieldConfigByType<"form">["configs"]["fields"];
+export type FormField = FormFields[number];
 
 export const FormRenderer = (
   props: CommonFabrixComponentRendererProps<{
-    fields: FormRendererFields;
+    fields: FormFields;
   }>,
 ) => {
   const { context, fieldConfigs, query, componentFieldsRenderer } = props;
@@ -94,7 +94,7 @@ export const FormRenderer = (
 
 const renderField = (props: {
   indexKey: string;
-  field: FormRendererField;
+  field: FormField;
   context: FabrixContextType;
   extraClassName?: string;
 }) => {

--- a/packages/fabrix/src/renderers/form/validation.ts
+++ b/packages/fabrix/src/renderers/form/validation.ts
@@ -1,6 +1,6 @@
-import { FormField } from "@renderers/form";
+import { FormRendererField, FormRendererFields } from "@renderers/form";
 
-const convertToAjvProperty = (field: FormField) => {
+const convertToAjvProperty = (field: FormRendererField) => {
   switch (field.meta?.fieldType?.type) {
     case "Scalar":
       switch (field.meta.fieldType.name) {
@@ -37,7 +37,7 @@ const convertToAjvProperty = (field: FormField) => {
   }
 };
 
-export const buildAjvSchema = (fields: Array<FormField>) => {
+export const buildAjvSchema = (fields: FormRendererFields) => {
   const visibleFields = fields.filter((field) => !field.config.hidden);
   const requiredFields = visibleFields.filter(
     (field) => field.meta?.isRequired,

--- a/packages/fabrix/src/renderers/form/validation.ts
+++ b/packages/fabrix/src/renderers/form/validation.ts
@@ -1,6 +1,6 @@
-import { FormRendererField, FormRendererFields } from "@renderers/form";
+import { FormField, FormFields } from "@renderers/form";
 
-const convertToAjvProperty = (field: FormRendererField) => {
+const convertToAjvProperty = (field: FormField) => {
   switch (field.meta?.fieldType?.type) {
     case "Scalar":
       switch (field.meta.fieldType.name) {
@@ -37,7 +37,7 @@ const convertToAjvProperty = (field: FormRendererField) => {
   }
 };
 
-export const buildAjvSchema = (fields: FormRendererFields) => {
+export const buildAjvSchema = (fields: FormFields) => {
   const visibleFields = fields.filter((field) => !field.config.hidden);
   const requiredFields = visibleFields.filter(
     (field) => field.meta?.isRequired,

--- a/packages/fabrix/src/renderers/shared.tsx
+++ b/packages/fabrix/src/renderers/shared.tsx
@@ -11,6 +11,7 @@ import {
 import { DirectiveAttributes } from "@registry";
 import { FabrixContextType } from "@context";
 import { FieldConfigWithMeta } from "@readers/shared";
+import { FieldConfig } from "@renderer";
 import { FabrixComponentData } from "../fetcher";
 
 type FabrixComponentFieldsRendererExtraProps = Partial<DirectiveAttributes> & {
@@ -92,6 +93,11 @@ export const assertObjectValue: (
 };
 
 export type FieldTypes = ReturnType<typeof resolveFieldTypesFromTypename>;
+
+export type FieldConfigByType<T extends FieldConfig["type"]> = Extract<
+  FieldConfig,
+  { type: T }
+>;
 
 export const getFieldConfigByKey = <C extends Record<string, unknown>>(
   fields: Array<FieldConfigWithMeta<C>>,


### PR DESCRIPTION
During working on #79, I am getting to feel urged to do some simplification for the renderer strategy decision.

The changes included in this PR are potentially conflictable in another changes, so let me split them out first from my another PR (#88)

## Changes

* Remove `fallbackDefault`: https://github.com/fabrix-framework/fabrix/pull/89/files#r1867379325
* Simplify pattern-matcher for renderer strategy: https://github.com/fabrix-framework/fabrix/pull/89/files#r1867387814
* Use type-inference: https://github.com/fabrix-framework/fabrix/pull/89/files#r1867391434