### PR TITLE
Multiple operation support

### DIFF
--- a/packages/fabrix/__tests__/mocks/handlers.ts
+++ b/packages/fabrix/__tests__/mocks/handlers.ts
@@ -12,6 +12,7 @@ type User {
 
 type UsersResult {
   collection: [User!]!
+  size: Int!
 }
 
 type Query {
@@ -39,6 +40,7 @@ type Mutation {
 const resolvers = {
   users: () => ({
     collection: users,
+    size: users.length,
   }),
 };
 

--- a/packages/fabrix/src/fetcher.ts
+++ b/packages/fabrix/src/fetcher.ts
@@ -1,28 +1,19 @@
 import { DocumentNode } from "graphql";
-import { useMemo } from "react";
 import { useClient, useQuery } from "urql";
 
 export const useDataFetch = (props: {
   query: DocumentNode | string;
   variables?: Record<string, unknown>;
-  defaultData?: FabrixComponentData;
 }) => {
-  // Stop the query from executing automatically by enabling the `pause` option.
-  // when the `defaultData` prop is provided.
-  const [{ data: queryData, fetching, error }] = useQuery<FabrixComponentData>({
+  const [{ data, fetching, error }] = useQuery<FabrixComponentData>({
     query: props.query,
-    pause: props.defaultData !== undefined,
     variables: props.variables,
   });
-
-  const renderingData = useMemo(() => {
-    return props.defaultData === undefined ? queryData : props.defaultData;
-  }, [props.defaultData, queryData]);
 
   return {
     fetching,
     error,
-    data: renderingData,
+    data,
   };
 };
 

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -208,12 +208,12 @@ type FabrixComponentChildrenProps = {
    * Get the operation result by operation name or index
    *
    * ```tsx
-   * <FabrixComponent query={appQuery}>
+   * <FabrixComponent query={getUsersQuery}>
    *   {({ getOperation }) => (
-   *     {getOperation("query1", ({ data, getComponent }) => (
+   *     {getOperation("getUsers", ({ data, getComponent }) => (
    *       <>
-   *         <h2>{data.size} users</h2>
-   *         {getComponent("getUsers")}
+   *         <h2>{data.users.size} users</h2>
+   *         {getComponent("users")}
    *       </>
    *     ))}
    *   )}

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -1,5 +1,5 @@
 import { DirectiveNode, DocumentNode, OperationTypeNode, parse } from "graphql";
-import { useCallback, useContext, useMemo } from "react";
+import { ReactNode, useCallback, useContext, useMemo } from "react";
 import { findDirective, parseDirectiveArguments } from "@directive";
 import { ViewRenderer } from "@renderers/fields";
 import { FormRenderer } from "@renderers/form";
@@ -194,14 +194,16 @@ type FabrixGetComponentFn = (
   name: string,
   extraProps?: FabrixComponentChildrenExtraProps,
   fieldsRenderer?: FabrixComponentFieldsRenderer,
-) => React.ReactNode;
-type FabrixGetOperationFn = (
+) => ReactNode;
+type FabrixGetOperationFn = <
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(
   indexOrName: number | string,
   renderer?: (props: {
-    data: FabrixComponentData;
+    data: T;
     getComponent: FabrixGetComponentFn;
-  }) => React.ReactNode,
-) => React.ReactNode;
+  }) => ReactNode,
+) => ReactNode;
 
 type FabrixComponentChildrenProps = {
   /**
@@ -237,7 +239,7 @@ type FabrixComponentChildrenProps = {
     rootFieldName: string,
     extraProps?: FabrixComponentChildrenExtraProps,
     fieldsRenderer?: FabrixComponentFieldsRenderer,
-  ) => React.ReactNode;
+  ) => ReactNode;
 };
 
 /**
@@ -264,7 +266,7 @@ type FabrixComponentChildrenProps = {
  */
 export const FabrixComponent = (
   props: FabrixComponentProps & {
-    children?: (props: FabrixComponentChildrenProps) => React.ReactNode;
+    children?: (props: FabrixComponentChildrenProps) => ReactNode;
   },
 ) => {
   const { fieldConfigs } = useFieldConfigs(props.query);
@@ -344,7 +346,7 @@ export const FabrixComponent = (
             operation={fieldConfig}
             variables={props.variables}
             getComponentFn={getComponentFn}
-            renderer={renderer}
+            renderer={renderer as Parameters<FabrixGetOperationFn>[1]}
           />
         );
       },

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -221,6 +221,23 @@ type FabrixComponentChildrenProps = {
    * ```
    */
   getOperation: FabrixGetOperationFn;
+  /**
+   * Get the component by root field name
+   *
+   * ```tsx
+   * <FabrixComponent query={getUsersQuery}>
+   *   {({ getComponent }) => (
+   *     {getComponent("getUsers", "users")}
+   *   )}
+   * </FabrixComponent>
+   * ```
+   */
+  getComponent: (
+    operationIndexOrName: number | string,
+    rootFieldName: string,
+    extraProps?: FabrixComponentChildrenExtraProps,
+    fieldsRenderer?: FabrixComponentFieldsRenderer,
+  ) => React.ReactNode;
 };
 
 /**
@@ -336,7 +353,18 @@ export const FabrixComponent = (
 
   const renderContents = () => {
     if (props.children) {
-      return props.children({ getOperation });
+      return props.children({
+        getOperation,
+        getComponent: (
+          operationIndexOrName,
+          rootFieldName,
+          extraProps,
+          fieldsRenderer,
+        ) =>
+          getOperation(operationIndexOrName, ({ getComponent }) =>
+            getComponent(rootFieldName, extraProps, fieldsRenderer),
+          ),
+      });
     }
 
     return fieldConfigs.map((_, i) => getOperation(i));

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -153,26 +153,6 @@ type FabrixComponentCommonProps = {
   variables?: Record<string, unknown>;
 
   /**
-   * The data to render the query with.
-   *
-   * If this parameter is given, the query will not be executed.
-   *
-   * The data structure is expected to be like this:
-   * ```
-   * {
-   *   getContract: {
-   *     id: "1",
-   *     name: "Contract name",
-   *     code: "C1",
-   *   }
-   * }
-   * ```
-   *
-   * The root key is the query name, and the value is the object with the field values.
-   */
-  data?: FabrixComponentData;
-
-  /**
    * The title of the query.
    */
   title?: string;
@@ -300,7 +280,7 @@ export const FabrixComponent = (
           return null;
       }
     },
-    [props.contentClassName, props.data, props.variables],
+    [props.contentClassName, props.variables],
   );
 
   const getComponentFn = useCallback(
@@ -346,7 +326,6 @@ export const FabrixComponent = (
             key={`fabrix-operation${typeof indexOrName === "number" ? `-${indexOrName}` : ""}-${fieldConfig.name}`}
             operation={fieldConfig}
             variables={props.variables}
-            defaultData={props.data}
             getComponentFn={getComponentFn}
             renderer={renderer}
           />
@@ -370,7 +349,6 @@ export type RendererCommonProps = {
   key: string;
   operation: FieldConfigs;
   variables: Record<string, unknown> | undefined;
-  defaultData: FabrixComponentData | undefined;
   renderer?: Parameters<FabrixGetOperationFn>[1];
   getComponentFn: (
     op: FieldConfigs,
@@ -391,7 +369,6 @@ const OperationRenderer = (props: RendererCommonProps) => {
 const QueryOperationRenderer = ({
   operation,
   variables,
-  defaultData,
   renderer,
   getComponentFn,
 }: RendererCommonProps) => {
@@ -399,7 +376,6 @@ const QueryOperationRenderer = ({
   const { fetching, error, data } = useDataFetch({
     query: operation.document,
     variables,
-    defaultData: defaultData?.[operation.name] as FabrixComponentData,
   });
 
   if (fetching || !data) {

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -5,9 +5,9 @@ import { ViewRenderer } from "@renderers/fields";
 import { FormRenderer } from "@renderers/form";
 import { FabrixContext, FabrixContextType } from "@context";
 import {
-  FieldTypes,
   FabrixComponentFieldsRenderer,
-  CommonFabrixComponentRendererProps,
+  Loader,
+  resolveFieldTypesFromTypename,
 } from "@renderers/shared";
 import { directiveSchemaMap } from "@directive/schema";
 import { mergeFieldConfigs } from "@readers/shared";
@@ -15,16 +15,14 @@ import { buildDefaultViewFieldConfigs, viewFieldMerger } from "@readers/field";
 import { buildDefaultFormFieldConfigs, formFieldMerger } from "@readers/form";
 import { buildRootDocument, FieldVariables } from "@/visitor";
 import { Field, Fields } from "@/visitor/fields";
-import { FabrixComponentData } from "@/fetcher";
+import { FabrixComponentData, useDataFetch, Value } from "@/fetcher";
 
 const decideStrategy = (
   directiveNodes: readonly DirectiveNode[],
   opType: OperationTypeNode,
 ) => {
   const directive = findDirective(directiveNodes);
-  const emptyDirective = {
-    arguments: null,
-  } as const;
+  const emptyDirective = { arguments: null } as const;
 
   switch (opType) {
     case OperationTypeNode.QUERY: {
@@ -41,10 +39,8 @@ const decideStrategy = (
           directive?.name === "fabrixForm" ? directive : emptyDirective,
       } as const;
     }
-    default: {
-      return null;
-    }
   }
+  return null;
 };
 
 /**
@@ -106,7 +102,12 @@ const getFieldConfig = (
 export type FieldConfig = ReturnType<typeof getFieldConfig> & {
   document: DocumentNode;
 };
-type FieldConfigs = Record<string, FieldConfig>;
+type FieldConfigs = {
+  name: string;
+  document: DocumentNode;
+  type: OperationTypeNode;
+  fields: FieldConfig[];
+};
 
 const useFieldConfigs = (query: DocumentNode | string) => {
   const rootDocument = buildRootDocument(
@@ -114,36 +115,35 @@ const useFieldConfigs = (query: DocumentNode | string) => {
   );
   const context = useContext(FabrixContext);
   const fieldConfigs = useMemo(() => {
-    return rootDocument.map(({ document, fields, opType, variables }) =>
+    return rootDocument.map(({ name, document, fields, opType, variables }) =>
       fields
         .unwrap()
         .filter((f) => !f.getParentName())
-        .reduce<FieldConfigs>((acc, field) => {
-          const fieldConfig = getFieldConfig(
-            context,
-            field,
-            variables,
-            fields.getChildrenWithAncestors(field.getName()),
-            opType,
-          );
-          if (!fieldConfig) {
-            return acc;
-          }
+        .reduce<FieldConfigs>(
+          (acc, field) => {
+            const fieldConfig = getFieldConfig(
+              context,
+              field,
+              variables,
+              fields.getChildrenWithAncestors(field.getName()),
+              opType,
+            );
+            if (!fieldConfig) {
+              return acc;
+            }
 
-          return {
-            ...acc,
-            [field.getName()]: {
-              document,
+            acc.fields.push({
               ...fieldConfig,
-            },
-          };
-        }, {}),
+              document,
+            });
+            return acc;
+          },
+          { name, document, type: opType, fields: [] },
+        ),
     );
   }, [rootDocument, context]);
 
-  return {
-    fieldConfigs,
-  };
+  return { fieldConfigs };
 };
 
 type FabrixComponentCommonProps = {
@@ -206,29 +206,41 @@ type FabrixComponentProps = FabrixComponentCommonProps & {
 };
 
 type FabrixComponentChildrenExtraProps = { key?: string; className?: string };
+
+type FabrixGetComponentFn = (
+  /**
+   * The name that corresponds to the GQL query.
+   */
+  name: string,
+  extraProps?: FabrixComponentChildrenExtraProps,
+  fieldsRenderer?: FabrixComponentFieldsRenderer,
+) => React.ReactNode;
+type FabrixGetOperationFn = (
+  indexOrName: number | string,
+  renderer?: (props: {
+    data: FabrixComponentData;
+    getComponent: FabrixGetComponentFn;
+  }) => React.ReactNode,
+) => React.ReactNode;
+
 type FabrixComponentChildrenProps = {
   /**
-   * Get the component by query name
+   * Get the operation result by operation name or index
    *
    * ```tsx
    * <FabrixComponent query={appQuery}>
-   *   {({ getComponent }) => (
-   *     <>
-   *       {getComponent("createEmployee")}
-   *       {getComponent("getEmployees")}
-   *     </>
+   *   {({ getOperation }) => (
+   *     {getOperation("query1", ({ data, getComponent }) => (
+   *       <>
+   *         <h2>{data.size} users</h2>
+   *         {getComponent("getUsers")}
+   *       </>
+   *     ))}
    *   )}
    * </FabrixComponent>
    * ```
    */
-  getComponent: (
-    /**
-     * The name that corresponds to the GQL query.
-     */
-    name: string,
-    extraProps?: FabrixComponentChildrenExtraProps,
-    fieldsRenderer?: FabrixComponentFieldsRenderer,
-  ) => React.ReactNode;
+  getOperation: FabrixGetOperationFn;
 };
 
 /**
@@ -262,26 +274,28 @@ export const FabrixComponent = (
   const renderByField = useCallback(
     (
       field: FieldConfig,
+      data: Value,
+      context: FabrixContextType,
       componentFieldsRenderer?: FabrixComponentFieldsRenderer,
     ) => {
-      const context = useContext(FabrixContext);
       const commonProps = {
-        query: {
-          documentResolver: () => field.document,
-          variables: props.variables,
-          rootName: field.name,
-        },
-        defaultData: props.data,
-        className: props.contentClassName,
-        componentFieldsRenderer,
         context,
+        rootField: {
+          name: field.name,
+          fields: field.configs.fields,
+          data,
+          type: resolveFieldTypesFromTypename(context, data),
+          document: field.document,
+          className: props.contentClassName,
+          componentFieldsRenderer,
+        },
       };
-
       switch (field.type) {
         case "view":
-          return <ViewRenderer {...commonProps} fieldConfigs={field.configs} />;
-        case "form":
-          return <FormRenderer {...commonProps} fieldConfigs={field.configs} />;
+          return <ViewRenderer {...commonProps} />;
+        case "form": {
+          return <FormRenderer {...commonProps} />;
+        }
         default:
           return null;
       }
@@ -289,51 +303,135 @@ export const FabrixComponent = (
     [props.contentClassName, props.data, props.variables],
   );
 
-  const getComponent: FabrixComponentChildrenProps["getComponent"] =
-    useCallback(
+  const getComponentFn = useCallback(
+    (
+      fieldConfig: FieldConfigs,
+      data: FabrixComponentData,
+      context: FabrixContextType,
+    ) =>
       (
         name: string,
         extraProps?: FabrixComponentChildrenExtraProps,
         componentFieldsRenderer?: FabrixComponentFieldsRenderer,
       ) => {
-        const fieldConfig = fieldConfigs.find((c) => c[name]);
-        if (!fieldConfig) {
-          return null;
+        const field = fieldConfig.fields.find((f) => f.name === name);
+        if (!field) {
+          throw new Error(`No root field found for name:${name}`);
         }
-
         return (
           <div
             key={extraProps?.key}
             className={`fabrix renderer container ${props.containerClassName ?? ""} ${extraProps?.className ?? ""}`}
           >
-            {renderByField(fieldConfig[name], componentFieldsRenderer)}
+            {renderByField(field, data[name], context, componentFieldsRenderer)}
           </div>
         );
       },
-      [fieldConfigs, renderByField, props.containerClassName],
+    [fieldConfigs, renderByField, props.containerClassName],
+  );
+
+  const getOperation: FabrixComponentChildrenProps["getOperation"] =
+    useCallback(
+      (indexOrName, renderer) => {
+        const fieldConfig =
+          typeof indexOrName === "number"
+            ? fieldConfigs[indexOrName]
+            : fieldConfigs.find(({ name }) => name == indexOrName);
+        if (!fieldConfig) {
+          throw new Error(`No operation found for indexOrName:${indexOrName}`);
+        }
+
+        return (
+          <OperationRenderer
+            key={`fabrix-operation${typeof indexOrName === "number" ? `-${indexOrName}` : ""}-${fieldConfig.name}`}
+            operation={fieldConfig}
+            variables={props.variables}
+            defaultData={props.data}
+            getComponentFn={getComponentFn}
+            renderer={renderer}
+          />
+        );
+      },
+      [fieldConfigs, getComponentFn],
     );
 
   const renderContents = () => {
     if (props.children) {
-      return props.children({
-        getComponent,
-      });
+      return props.children({ getOperation });
     }
 
-    return fieldConfigs.map((c) =>
-      Object.keys(c).map((queryKey, index) =>
-        getComponent(queryKey, { key: `renderer-${index}` }),
-      ),
-    );
+    return fieldConfigs.map((_, i) => getOperation(i));
   };
 
   return <div className="fabrix wrapper">{renderContents()}</div>;
 };
 
 export type RendererCommonProps = {
-  fieldTypes: FieldTypes;
-  context: FabrixContextType;
-  renderingData: FabrixComponentData | undefined;
-  query: CommonFabrixComponentRendererProps["query"];
+  key: string;
+  operation: FieldConfigs;
+  variables: Record<string, unknown> | undefined;
+  defaultData: FabrixComponentData | undefined;
+  renderer?: Parameters<FabrixGetOperationFn>[1];
+  getComponentFn: (
+    op: FieldConfigs,
+    data: FabrixComponentData,
+    context: FabrixContextType,
+  ) => FabrixGetComponentFn;
   extraClassName?: string;
+};
+
+const OperationRenderer = (props: RendererCommonProps) => {
+  return props.operation.type === OperationTypeNode.MUTATION ? (
+    <MutateOperationRenderer {...props} />
+  ) : (
+    <QueryOperationRenderer {...props} />
+  );
+};
+
+const QueryOperationRenderer = ({
+  operation,
+  variables,
+  defaultData,
+  renderer,
+  getComponentFn,
+}: RendererCommonProps) => {
+  const context = useContext(FabrixContext);
+  const { fetching, error, data } = useDataFetch({
+    query: operation.document,
+    variables,
+    defaultData: defaultData?.[operation.name] as FabrixComponentData,
+  });
+
+  if (fetching || !data) {
+    return <Loader />;
+  }
+
+  if (error) {
+    throw error;
+  }
+
+  const getComponent = getComponentFn(operation, data, context);
+  return renderer
+    ? renderer({ data, getComponent })
+    : operation.fields.map((field) =>
+        getComponent(field.name, {
+          key: `fabrix-query-${operation.name}-${field.name}`,
+        }),
+      );
+};
+
+const MutateOperationRenderer = ({
+  operation,
+  renderer,
+  getComponentFn,
+}: RendererCommonProps) => {
+  const context = useContext(FabrixContext);
+  const getComponent = getComponentFn(operation, {}, context);
+  return renderer
+    ? renderer({ data: {}, getComponent })
+    : operation.fields.map((field) =>
+        getComponent(field.name, {
+          key: `fabrix-mutation-${operation.name}-${field.name}`,
+        }),
+      );
 };

--- a/packages/fabrix/src/renderers/shared.tsx
+++ b/packages/fabrix/src/renderers/shared.tsx
@@ -12,7 +12,7 @@ import { DirectiveAttributes } from "@registry";
 import { FabrixContextType } from "@context";
 import { FieldConfigWithMeta } from "@readers/shared";
 import { FieldConfig } from "@renderer";
-import { FabrixComponentData } from "../fetcher";
+import { Value } from "@fetcher";
 
 type FabrixComponentFieldsRendererExtraProps = Partial<DirectiveAttributes> & {
   key?: string;
@@ -51,13 +51,17 @@ export type RendererQuery = {
   variables: Record<string, unknown> | undefined;
   documentResolver: DocumentResolver;
 };
-export type CommonFabrixComponentRendererProps<T = Record<string, unknown>> = {
-  query: RendererQuery;
-  fieldConfigs: T;
-  className?: string;
-  defaultData: FabrixComponentData | undefined;
+export type CommonFabrixComponentRendererProps<F> = {
   context: FabrixContextType;
+  rootField: {
+    name: string;
+    fields: F;
+    data: Value;
+    type: Record<string, FieldType>;
+    document: DocumentNode;
+  };
   componentFieldsRenderer?: FabrixComponentFieldsRenderer;
+  className?: string;
 };
 
 export const buildClassName = <
@@ -115,7 +119,7 @@ export type ObjectLikeValue =
 export const resolveFieldTypesFromTypename = (
   context: FabrixContextType,
   values: ObjectLikeValue,
-) => {
+): Record<string, FieldType> => {
   if (!values) {
     return {};
   }


### PR DESCRIPTION
Add support for multiple operations in the `FabrixComponent` component.
- add `getOperation` method to the `FabrixComponent` component to retrieve data from the operation root
  - move existing `getComponent` method into parameter
  - solve #75 
- change `getComponent` with operation identifier.
- add test for `FabrixComponent` with children.
- remove the `defaultData` property from the `FabrixComponent` component and `useDataFetch`