### PR TITLE
Nested field selection support

### DIFF
--- a/packages/fabrix/__tests__/mocks/data.ts
+++ b/packages/fabrix/__tests__/mocks/data.ts
@@ -5,10 +5,20 @@ export const users = [
     id: faker.string.uuid(),
     name: "first user",
     email: faker.internet.email(),
+    category: "ADMIN",
+    address: {
+      city: faker.location.city(),
+      street: faker.location.street(),
+      zip: faker.location.zipCode(),
+    },
   },
   {
     id: faker.string.uuid(),
     name: "second user",
     email: faker.internet.email(),
+    category: "USER",
+    address: {
+      zip: faker.location.zipCode(),
+    },
   },
 ];

--- a/packages/fabrix/__tests__/mocks/data.ts
+++ b/packages/fabrix/__tests__/mocks/data.ts
@@ -5,6 +5,7 @@ export const users = [
     id: faker.string.uuid(),
     name: "first user",
     email: faker.internet.email(),
+    age: faker.number.int({ min: 18, max: 99 }),
     category: "ADMIN",
     address: {
       city: faker.location.city(),
@@ -16,6 +17,7 @@ export const users = [
     id: faker.string.uuid(),
     name: "second user",
     email: faker.internet.email(),
+    age: faker.number.int({ min: 18, max: 99 }),
     category: "USER",
     address: {
       zip: faker.location.zipCode(),

--- a/packages/fabrix/__tests__/mocks/handlers.ts
+++ b/packages/fabrix/__tests__/mocks/handlers.ts
@@ -21,6 +21,7 @@ type User implements Node {
   id: ID!
   name: String!
   email: String!
+  age: Int!
   category: UserCategory!
   address: UserAddress!
 }

--- a/packages/fabrix/__tests__/mocks/handlers.ts
+++ b/packages/fabrix/__tests__/mocks/handlers.ts
@@ -21,6 +21,8 @@ type User implements Node {
   id: ID!
   name: String!
   email: String!
+  category: UserCategory!
+  address: UserAddress!
 }
 
 type UsersResult {
@@ -39,8 +41,15 @@ type UsersConnection {
 }
 
 type Query {
+  firstUser: User
   users: UsersResult
   userEdges: UsersConnection
+}
+
+type UserAddress {
+  city: String
+  street: String
+  zip: String!
 }
 
 enum UserCategory {
@@ -62,6 +71,7 @@ type Mutation {
 `);
 
 const resolvers = {
+  firstUser: () => users[0],
   users: () => ({
     collection: users,
     size: users.length,

--- a/packages/fabrix/__tests__/query.test.tsx
+++ b/packages/fabrix/__tests__/query.test.tsx
@@ -53,7 +53,11 @@ describe("collection", () => {
         collection {
           id
           name
-          email
+          age
+          category
+          address {
+            zip
+          }
         }
       }
     }
@@ -66,7 +70,11 @@ describe("collection", () => {
           node {
             id
             name
-            email
+            age
+            category
+            address {
+              zip
+            }
           }
         }
       }
@@ -108,83 +116,30 @@ describe("collection", () => {
           );
           const headerNames = headers.map((v) => v.textContent);
           expect(headerNames).toEqual([
-            "id (Scalar)",
-            "name (Scalar)",
-            "email (Scalar)",
+            "id (Scalar:ID)",
+            "name (Scalar:String)",
+            "age (Scalar:Int)",
+            "category (Enum:UserCategory)",
+            "zip (Scalar:String)",
           ]);
 
           const cells = await within(rowGroups[1]).findAllByRole("cell");
           expect(cells.map((v) => v.textContent)).toEqual([
             users[0].id,
             users[0].name,
-            users[0].email,
+            users[0].age + "",
+            users[0].category,
+            users[0].address.zip,
             users[1].id,
             users[1].name,
-            users[1].email,
+            users[1].age + "",
+            users[1].category,
+            users[1].address.zip,
           ]);
         },
       );
     },
   );
-
-  it.each([
-    [
-      "collection",
-      `query getUsers {
-        users {
-          collection {
-            id
-            name
-            address {
-              city
-              street
-              zip
-            }
-          }
-        }
-      }`,
-    ],
-    [
-      "edges",
-      `query getUsers {
-        userEdges {
-          edges {
-            node {
-              id
-              name
-              address {
-                city
-                street
-                zip
-              }
-            }
-          }
-        }
-      }`,
-    ],
-  ])("should render the table with nested fields (%s)", async (_, query) => {
-    await testWithUnmount(<FabrixComponent query={query} />, async () => {
-      const table = await screen.findByRole("table");
-      expect(table).toBeInTheDocument();
-
-      const rows = await within(table).findAllByRole("row");
-      expect(rows.length).toBe(users.length + 1);
-
-      const user = users[0];
-      const cells = await within(rows[1]).findAllByRole("cell");
-      const cellValues = cells.map((cell) => cell.textContent);
-
-      expect(cellValues).toEqual(
-        expect.arrayContaining([
-          user.id,
-          user.name,
-          user.address.city,
-          user.address.street,
-          user.address.zip,
-        ]),
-      );
-    });
-  });
 
   it("should render the table with customized labels", async () => {
     await testWithUnmount(

--- a/packages/fabrix/__tests__/supports/components.tsx
+++ b/packages/fabrix/__tests__/supports/components.tsx
@@ -7,19 +7,42 @@ import {
 } from "@registry";
 import { ReactNode } from "react";
 import { useController } from "react-hook-form";
+import { get } from "es-toolkit/compat";
 
 const fieldView = (props: FieldComponentProps) => {
-  const { value } = props;
+  const { value, type, name } = props;
 
-  return <span>{value as string}</span>;
+  if (type?.type === "Object" || type?.type === "List") {
+    return null;
+  }
+
+  return (
+    <div role="region">
+      <label>{name}:</label>
+      <span>{value as ReactNode}</span>
+    </div>
+  );
 };
 
 const tableView = (props: TableComponentProps) => {
+  const headers = props.headers.flatMap((header) => {
+    if (header.type?.type === "Object" || header.type?.type === "List") {
+      return [];
+    }
+
+    return [
+      {
+        key: header.key,
+        label: header.label,
+      },
+    ];
+  });
+
   return (
     <table>
       <thead>
         <tr>
-          {props.headers.map((header) => (
+          {headers.map((header) => (
             <th key={header.key}>{header.label}</th>
           ))}
         </tr>
@@ -27,8 +50,8 @@ const tableView = (props: TableComponentProps) => {
       <tbody>
         {props.values.map((item, index) => (
           <tr key={index}>
-            {props.headers.map((header) => (
-              <td key={header.key}>{item[header.key] as ReactNode}</td>
+            {headers.map((header) => (
+              <td key={header.key}>{get(item, header.key) as ReactNode}</td>
             ))}
           </tr>
         ))}

--- a/packages/fabrix/__tests__/supports/components.tsx
+++ b/packages/fabrix/__tests__/supports/components.tsx
@@ -33,7 +33,7 @@ const tableView = (props: TableComponentProps) => {
     return [
       {
         key: header.key,
-        label: `${header.label} (${header.type?.type})`,
+        label: `${header.label} (${header.type?.type}:${header.type?.name})`,
       },
     ];
   });

--- a/packages/fabrix/package.json
+++ b/packages/fabrix/package.json
@@ -32,6 +32,7 @@
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
     "deepmerge-ts": "^7.1.0",
+    "es-toolkit": "^1.30.1",
     "graphql-tag": "^2.12.6",
     "react-hook-form": "^7.53.1",
     "urql": "^4.2.1",

--- a/packages/fabrix/src/registry.tsx
+++ b/packages/fabrix/src/registry.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from "react";
+import { ComponentType } from "react";
 import { FabrixComponentProps } from "@renderer";
 import { ViewFieldSchema } from "@directive/schema";
 import { FieldType } from "@renderers/shared";

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -105,7 +105,10 @@ export const getSubFields = (
 ) =>
   // filters fields by parent key and maps the filtered values to the array of SubField
   fields
-    .filter((f) => f.field.getParent()?.asKey().startsWith(name))
+    .filter((f) => {
+      const parentKey = f.field.getParent()?.asKey();
+      return parentKey === name || parentKey?.startsWith(`${name}.`)
+    })
     .sort((a, b) => (a.config.index ?? 0) - (b.config.index ?? 0))
     .map((value) => ({
       value,

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -160,7 +160,6 @@ const renderField = ({
     };
   }, {});
 
-  const fieldName = field.field.getName();
   const className = buildClassName(field.config, extraClassName);
   const name = field.field.asKey();
   return createElement(component, {

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -1,6 +1,7 @@
 import { createElement, useCallback, useContext, useMemo } from "react";
 import { FabrixContext, FabrixContextType } from "@context";
 import { Value } from "@fetcher";
+import { get } from "es-toolkit/compat";
 import {
   assertObjectValue,
   buildClassName,
@@ -115,7 +116,7 @@ export const getSubFields = (
 ) =>
   // filters fields by parent key and maps the filtered values to the array of SubField
   fields
-    .filter((f) => f.field.getParent()?.asKey() === name)
+    .filter((f) => f.field.getParent()?.asKey().startsWith(name))
     .sort((a, b) => (a.config.index ?? 0) - (b.config.index ?? 0))
     .map((value) => ({
       value,
@@ -173,11 +174,12 @@ const renderField = ({
   }, {});
 
   const className = buildClassName(field.config, extraClassName);
+  const name = field.field.asKey();
   return createElement(component, {
     key: indexKey,
-    name: field.field.asKey(),
+    name,
     path: field.field.value,
-    value: rootField.data?.[fieldName] ?? "-",
+    value: get(rootField.data, name),
     type: fieldType,
     subFields: subFields.map((subField) => ({
       key: subField.value.field.getName(),

--- a/packages/fabrix/src/renderers/table.tsx
+++ b/packages/fabrix/src/renderers/table.tsx
@@ -70,16 +70,12 @@ export const renderTableElement = (props: {
   }
 
   const { component, tableMode } = props;
-  const subFields = getSubFields(
-    context,
-    rootValue,
-    fields,
-    tableMode == "standard" ? "collection" : "edges.node",
-  );
+  const basePath = tableMode == "standard" ? "collection" : "edges.node";
+  const subFields = getSubFields(context, rootValue, fields, basePath);
 
   const element = createElement(component, {
     name,
-    headers: buildHeaders(context, subFields),
+    headers: buildHeaders(context, subFields, basePath),
     values: getTableValues(rootValue, tableMode),
     customProps: props.customProps,
   });
@@ -90,6 +86,7 @@ export const renderTableElement = (props: {
 export const buildHeaders = (
   context: FabrixContextType,
   subFields: SubFields,
+  basePath: string,
 ) =>
   subFields.flatMap((subField) => {
     if (subField.value.config.hidden) {
@@ -111,17 +108,18 @@ export const buildHeaders = (
       {},
     );
 
-    const key = subField.value.field.getName();
+    const key = subField.value.field.asKey().slice(basePath.length + 1);
+    const name = subField.value.field.getName();
     const cellRenderer = component
       ? (rowValue: Record<string, unknown>) => {
           return createElement(component, {
             key,
-            name: key,
+            name,
             path: subField.value.field.value,
             type: subField.type,
             value: rowValue,
             subFields: subFields.map((subField) => ({
-              key: subField.value.field.getName(),
+              key: subField.value.field.asKey().slice(basePath.length + 1),
               label: subField.label,
               type: subField.type,
             })),
@@ -135,8 +133,8 @@ export const buildHeaders = (
       : null;
 
     return {
+      key,
       label: subField.label,
-      key: subField.value.field.getName(),
       type: subField.type,
       render: cellRenderer,
     };

--- a/packages/fabrix/src/renderers/typename.test.ts
+++ b/packages/fabrix/src/renderers/typename.test.ts
@@ -115,6 +115,7 @@ describe("resolveTypenameByPath", () => {
       id: { type: "Scalar", name: "ID" },
       name: { type: "Scalar", name: "String" },
       email: { type: "Scalar", name: "String" },
+      age: { type: "Scalar", name: "Int" },
       category: {
         type: "Enum",
         name: "UserCategory",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,6 +206,9 @@ importers:
       deepmerge-ts:
         specifier: ^7.1.0
         version: 7.1.3
+      es-toolkit:
+        specifier: ^1.30.1
+        version: 1.30.1
       graphql:
         specifier: ^16
         version: 16.9.0
@@ -342,7 +345,7 @@ importers:
         version: 9.1.0(eslint@9.12.0)
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.31.0(eslint@9.12.0)
+        version: 2.31.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint@9.12.0)
       typescript:
         specifier: ^5
         version: 5.6.3
@@ -2274,6 +2277,9 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.30.1:
+    resolution: {integrity: sha512-ZXflqanzH8BpHkDhFa10bBf6ONDCe84EPUm7SSICGzuuROSluT2ynTPtwn9PcRelMtorCRozSknI/U0MNYp0Uw==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -6035,6 +6041,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.30.1: {}
+
   esbuild@0.21.5:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.21.5
@@ -6135,16 +6143,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.12.0):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.12.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.8.1(eslint@9.12.0)(typescript@5.6.3)
       eslint: 9.12.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(eslint@9.12.0):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint@9.12.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -6155,7 +6164,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.12.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.12.0)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.8.1(eslint@9.12.0)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint@9.12.0)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -6166,6 +6175,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.8.1(eslint@9.12.0)(typescript@5.6.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
Extracted changes from #105 that focus only on #40

## Changes

Fabrix currently renders only the root fields of the queries, but with this PR, it would render the all fields selected including nested ones. This change is also applied to the value passed on to the custom components as well.

