### PR TITLE
Add a typename extractor module and its tests

### DIFF
--- a/packages/fabrix/__tests__/mocks/data.ts
+++ b/packages/fabrix/__tests__/mocks/data.ts
@@ -5,10 +5,20 @@ export const users = [
     id: faker.string.uuid(),
     name: "first user",
     email: faker.internet.email(),
+    category: "ADMIN",
+    address: {
+      city: faker.location.city(),
+      street: faker.location.street(),
+      zip: faker.location.zipCode(),
+    },
   },
   {
     id: faker.string.uuid(),
     name: "second user",
     email: faker.internet.email(),
+    category: "USER",
+    address: {
+      zip: faker.location.zipCode(),
+    },
   },
 ];

--- a/packages/fabrix/__tests__/mocks/handlers.ts
+++ b/packages/fabrix/__tests__/mocks/handlers.ts
@@ -3,7 +3,7 @@ import { buildSchema, graphql as executeGraphql } from "graphql";
 import { ObjMap } from "graphql/jsutils/ObjMap";
 import { users } from "./data";
 
-const mockSchema = buildSchema(`
+export const mockSchema = buildSchema(`
 # Relay Node
 interface Node {
   id: ID!

--- a/packages/fabrix/__tests__/mocks/handlers.ts
+++ b/packages/fabrix/__tests__/mocks/handlers.ts
@@ -21,6 +21,8 @@ type User implements Node {
   id: ID!
   name: String!
   email: String!
+  category: UserCategory!
+  address: UserAddress!
 }
 
 type UsersResult {
@@ -39,8 +41,15 @@ type UsersConnection {
 }
 
 type Query {
+  firstUser: User
   users: UsersResult
   userEdges: UsersConnection
+}
+
+type UserAddress {
+  city: String
+  street: String
+  zip: String!
 }
 
 enum UserCategory {
@@ -62,6 +71,7 @@ type Mutation {
 `);
 
 const resolvers = {
+  firstUser: () => users[0],
   users: () => ({
     collection: users,
     size: users.length,

--- a/packages/fabrix/__tests__/supports/components.tsx
+++ b/packages/fabrix/__tests__/supports/components.tsx
@@ -15,11 +15,18 @@ const fieldView = (props: FieldComponentProps) => {
 };
 
 const tableView = (props: TableComponentProps) => {
+  const headers = props.headers.map((header) => {
+    return {
+      key: header.key,
+      label: `${header.label} (${header.type?.type})`,
+    };
+  });
+
   return (
     <table>
       <thead>
         <tr>
-          {props.headers.map((header) => (
+          {headers.map((header) => (
             <th key={header.key}>{header.label}</th>
           ))}
         </tr>
@@ -27,7 +34,7 @@ const tableView = (props: TableComponentProps) => {
       <tbody>
         {props.values.map((item, index) => (
           <tr key={index}>
-            {props.headers.map((header) => (
+            {headers.map((header) => (
               <td key={header.key}>{item[header.key] as ReactNode}</td>
             ))}
           </tr>

--- a/packages/fabrix/src/context.tsx
+++ b/packages/fabrix/src/context.tsx
@@ -12,7 +12,7 @@ import {
 import { createContext, useCallback, useContext } from "react";
 import { ComponentRegistry, emptyComponentRegistry } from "@registry";
 
-type SchemaSet = {
+export type SchemaSet = {
   serverSchema: GraphQLSchema;
   operationSchema?: DocumentNode;
 };

--- a/packages/fabrix/src/index.ts
+++ b/packages/fabrix/src/index.ts
@@ -3,7 +3,7 @@ export { useFabrixContext } from "@context";
 export { gql } from "graphql-tag";
 export { FabrixComponent } from "@renderer";
 export { useFabrixClient, useDataFetch } from "@fetcher";
-export { type FieldType } from "@renderers/shared";
+export { type FieldType } from "@renderers/typename";
 export { type SubField } from "@renderers/fields";
 export {
   type FieldComponentEntry,

--- a/packages/fabrix/src/readers/form.ts
+++ b/packages/fabrix/src/readers/form.ts
@@ -4,7 +4,7 @@ import {
   FormFieldSchema,
   formFieldSchema,
 } from "@directive/schema";
-import { resolveFieldType } from "@renderers/shared";
+import { resolveFieldType } from "@renderers/typename";
 import { FieldVariables } from "@visitor";
 import { Path } from "@visitor/path";
 import { deepmerge } from "deepmerge-ts";

--- a/packages/fabrix/src/readers/shared.ts
+++ b/packages/fabrix/src/readers/shared.ts
@@ -1,4 +1,4 @@
-import { FieldType } from "@renderers/shared";
+import { FieldType } from "@renderers/typename";
 import { Path } from "@visitor/path";
 
 type FieldMeta = {

--- a/packages/fabrix/src/registry.tsx
+++ b/packages/fabrix/src/registry.tsx
@@ -1,7 +1,7 @@
 import { ComponentType, ReactNode } from "react";
 import { FabrixComponentProps } from "@renderer";
 import { ViewFieldSchema } from "@directive/schema";
-import { FieldType } from "@renderers/shared";
+import { FieldType } from "@renderers/typename";
 import { FabrixCustomComponent } from "@customRenderer";
 import {
   ComponentTypeByName,

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -4,11 +4,7 @@ import { findDirective, parseDirectiveArguments } from "@directive";
 import { ViewRenderer } from "@renderers/fields";
 import { FormRenderer } from "@renderers/form";
 import { FabrixContext, FabrixContextType } from "@context";
-import {
-  FabrixComponentFieldsRenderer,
-  Loader,
-  resolveFieldTypesFromTypename,
-} from "@renderers/shared";
+import { FabrixComponentFieldsRenderer, Loader } from "@renderers/shared";
 import { directiveSchemaMap } from "@directive/schema";
 import { mergeFieldConfigs } from "@readers/shared";
 import { buildDefaultViewFieldConfigs, viewFieldMerger } from "@readers/field";
@@ -285,7 +281,6 @@ export const FabrixComponent = (props: FabrixComponentProps) => {
             name: field.name,
             fields: field.configs.fields,
             data,
-            type: resolveFieldTypesFromTypename(context, data),
             document: field.document,
             className: props.contentClassName,
             componentFieldsRenderer,

--- a/packages/fabrix/src/renderers/form.tsx
+++ b/packages/fabrix/src/renderers/form.tsx
@@ -1,15 +1,15 @@
 import { createElement, useCallback } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { useMutation } from "urql";
-import { FabrixContextType } from "../context";
+import { defaultFieldType } from "@renderers/typename";
+import { FabrixContextType } from "@context";
 import {
   buildClassName,
   CommonFabrixComponentRendererProps,
-  defaultFieldType,
   FieldConfigByType,
   getFieldConfigByKey,
   Loader,
-} from "./shared";
+} from "@renderers/shared";
 import { buildAjvSchema } from "./form/validation";
 import { ajvResolver } from "./form/ajvResolver";
 

--- a/packages/fabrix/src/renderers/typename.test.ts
+++ b/packages/fabrix/src/renderers/typename.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { mockSchema } from "../../__tests__/mocks/handlers";
+import { buildTypenameExtractor } from "./typename";
+
+const schemaSet = {
+  serverSchema: mockSchema,
+};
+
+describe("typenamesByPath", () => {
+  it("should extract __typename fields from nested objects", () => {
+    const targetValue = {
+      user: {
+        id: "1",
+        name: "John",
+        address: {
+          city: "New York",
+          __typename: "UserAddress",
+        },
+        contacts: [
+          {
+            name: "primary",
+            email: [
+              {
+                type: "work",
+                value: "john@example.com",
+                __typename: "UserContactEmail",
+              },
+            ],
+            __typename: "UserContact",
+          },
+        ],
+        __typename: "User",
+      },
+    };
+
+    const expectedOutput = {
+      user: "User",
+      "user.address": "UserAddress",
+      "user.contacts": "UserContact",
+      "user.contacts.email": "UserContactEmail",
+    };
+
+    const te = buildTypenameExtractor({
+      targetValue,
+      schemaSet,
+    });
+
+    expect(te.typenamesByPath).toEqual(expectedOutput);
+  });
+
+  it("should return null for non-object input", () => {
+    const te = buildTypenameExtractor({
+      targetValue: undefined,
+      schemaSet,
+    });
+
+    expect(te.typenamesByPath).toEqual({});
+  });
+
+  it("should return an empty object for an empty input object", () => {
+    const te = buildTypenameExtractor({
+      targetValue: {},
+      schemaSet,
+    });
+
+    expect(te.typenamesByPath).toEqual({});
+  });
+
+  it("should handle objects without __typename fields", () => {
+    const input = {
+      user: {
+        id: "1",
+        name: "John",
+        address: {
+          city: "New York",
+        },
+        contacts: [
+          {
+            email: "john@example.com",
+          },
+        ],
+      },
+    };
+
+    const te = buildTypenameExtractor({
+      targetValue: input,
+      schemaSet,
+    });
+
+    expect(te.typenamesByPath).toEqual({});
+  });
+});
+
+describe("resolveTypenameByPath", () => {
+  const input = {
+    user: {
+      id: "1",
+      name: "John",
+      category: "ADMIN",
+      address: {
+        city: "New York",
+        __typename: "UserAddress",
+      },
+      __typename: "User",
+    },
+  };
+
+  it("should resolve types from simple path", () => {
+    expect(
+      buildTypenameExtractor({
+        targetValue: input,
+        schemaSet,
+      }).resolveTypenameByPath("user"),
+    ).toStrictEqual({
+      id: { type: "Scalar", name: "ID" },
+      name: { type: "Scalar", name: "String" },
+      email: { type: "Scalar", name: "String" },
+      category: {
+        type: "Enum",
+        name: "UserCategory",
+        meta: { values: ["ADMIN", "USER"] },
+      },
+      address: { type: "Object", name: "UserAddress" },
+    });
+  });
+
+  it("should resolve types from nested path", () => {
+    expect(
+      buildTypenameExtractor({
+        targetValue: input,
+        schemaSet,
+      }).resolveTypenameByPath("user.address"),
+    ).toStrictEqual({
+      city: { type: "Scalar", name: "String" },
+      street: { type: "Scalar", name: "String" },
+      zip: { type: "Scalar", name: "String" },
+    });
+  });
+});

--- a/packages/fabrix/src/renderers/typename.ts
+++ b/packages/fabrix/src/renderers/typename.ts
@@ -1,0 +1,219 @@
+import { SchemaSet } from "@context";
+import {
+  GraphQLEnumType,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLNullableType,
+  GraphQLObjectType,
+  GraphQLOutputType,
+  GraphQLScalarType,
+  GraphQLType,
+} from "graphql";
+import { Path } from "@visitor/path";
+
+/*
+ * A function extract the __typename field from the target value.
+ *
+ * `targetValue` param like this:
+ * ```
+ * {
+ *   user: {
+ *    id: "1",
+ *    name: "John",
+ *    address: {
+ *      city: "New York",
+ *      __typename: "UserAddress",
+ *    },
+ *    contacts: [
+ *      {
+ *        email: "john@example.com"
+ *        __typename: "UserContact",
+ *      }
+ *    ],
+ *     __typename: "User",
+ *   }
+ * }
+ * ```
+ */
+export const buildTypenameExtractor = (props: {
+  targetValue: ObjectLikeValue;
+  schemaSet: SchemaSet;
+}) => {
+  const { targetValue, schemaSet } = props;
+  const typenamesByPath: Record<string, string> = {};
+  const traverse = (value: ObjectLikeValue, path: string) => {
+    if (Array.isArray(value)) {
+      value.forEach((item) => {
+        traverse(item as typeof value, path);
+      });
+    } else if (value && typeof value === "object") {
+      const typename = (value as { __typename?: string }).__typename;
+      if (typeof typename === "string") {
+        typenamesByPath[path] = typename;
+      }
+      for (const key of Object.keys(value)) {
+        if (key !== "__typename") {
+          traverse(
+            value[key] as Record<string, unknown>,
+            path ? `${path}.${key}` : key,
+          );
+        }
+      }
+    }
+  };
+
+  const resolveTypenameByPath = (path: string | undefined) => {
+    // If the path is undefined, it works accessing the root object to get the __typename.
+    // Traverser creates an structure as the empty path is the root object.
+    const typename = typenamesByPath[path ?? ""];
+    const valueType = schemaSet.serverSchema.getType(typename);
+    if (!(valueType instanceof GraphQLObjectType)) {
+      return {};
+    }
+
+    const fields = valueType.getFields();
+    return Object.keys(fields).reduce<Record<string, FieldType>>((acc, key) => {
+      const field = fields[key];
+      const typeInfo = resolveFieldType(field.type);
+      if (!typeInfo) {
+        return acc;
+      }
+
+      return {
+        ...acc,
+        [key]: typeInfo,
+      };
+    }, {});
+  };
+
+  const getFieldTypeByPath = (path: Path) => {
+    const typeInfo = resolveTypenameByPath(path.getParent()?.asKey());
+    return typeInfo[path.getName()] ?? null;
+  };
+
+  traverse(targetValue, "");
+
+  return {
+    /**
+     * A function to resolve the type information by the path.
+     *
+     * With this input:
+     * ```
+     * {
+     *   user: {
+     *     id: "1",
+     *      name: "John",
+     *     address: {
+     *       city: "New York",
+     *       __typename: "UserAddress",
+     *     },
+     *   },
+     * }
+     * ```
+     *
+     * If you call `resolveTypenameByPath("user.address")`, you will get the following result:
+     * ```
+     * {
+     *   "city: { type: "Scalar", name: "String" },
+     * }
+     * ```
+     */
+    resolveTypenameByPath,
+
+    /**
+     * A map of the __typename field by the path.
+     *
+     * For example, the result can be as follows:
+     * ```
+     * {
+     *   "": "User",
+     *   "address": "UserAddress",
+     *   "contacts": "UserContact",
+     * }
+     * ```
+     */
+    typenamesByPath,
+
+    /**
+     * A function to get the field type by the path.
+     */
+    getFieldTypeByPath,
+  };
+};
+
+export type TypenameExtractor = ReturnType<typeof buildTypenameExtractor>;
+
+type ObjectLikeValue =
+  | Record<string, unknown>
+  | Record<string, Array<NonNullable<ObjectLikeValue>>>
+  | Array<NonNullable<ObjectLikeValue>>
+  | undefined;
+
+const newScalarTypeField = (field: GraphQLScalarType) => {
+  return {
+    type: "Scalar" as const,
+    name: field.name,
+  };
+};
+
+const newEnumTypeField = (field: GraphQLEnumType) => {
+  return {
+    type: "Enum" as const,
+    name: field.name,
+    meta: {
+      values: field.getValues().map((value) => value.name),
+    },
+  };
+};
+
+const newObjectTypeField = (field: GraphQLObjectType) => {
+  return {
+    type: "Object" as const,
+    name: field.name,
+  };
+};
+
+const newListTypeField = (field: GraphQLList<GraphQLType>) => {
+  const innerType = resolveFieldType(field.ofType);
+  if (!innerType) {
+    return null;
+  }
+
+  return {
+    type: "List" as const,
+    innerType: innerType,
+  };
+};
+
+type ScalarType = ReturnType<typeof newScalarTypeField>;
+type EnumType = ReturnType<typeof newEnumTypeField>;
+type ObjectType = ReturnType<typeof newObjectTypeField>;
+type ListType = {
+  type: "List";
+  innerType: NonNullable<FieldType>;
+};
+
+export type FieldType = ScalarType | EnumType | ObjectType | ListType | null;
+export const defaultFieldType = {
+  type: "Scalar" as const,
+  name: "String",
+};
+
+export const resolveFieldType = (
+  field: GraphQLOutputType | GraphQLNullableType,
+): FieldType => {
+  if (field instanceof GraphQLScalarType) {
+    return newScalarTypeField(field);
+  } else if (field instanceof GraphQLEnumType) {
+    return newEnumTypeField(field);
+  } else if (field instanceof GraphQLObjectType) {
+    return newObjectTypeField(field);
+  } else if (field instanceof GraphQLList) {
+    return newListTypeField(field);
+  } else if (field instanceof GraphQLNonNull) {
+    return resolveFieldType(field.ofType);
+  } else {
+    // Interface is not supported as well
+    return null;
+  }
+};


### PR DESCRIPTION
A bugfix for #109 

## Background

The current implemenation to look up data types of each field selected in the query is looking into the value of `__typename` value from the query result, but found that it only covers the case that query has collection style.

As a fix for that, this PR adds a new implementation to extract information from `__typename` which is called `buildTypenameExtractor` that is implemented in `src/renderers/typename.ts` and replaced with the current implementation. It is designed to be independent enough to be testable and encapsulate the logic to extract types from the query result with some useful utility functions. Tests for the new implementation are added in `src/renderers/typename.test.ts` as well.

## Why `__typename` extractor is needed?

`DocumentNode` that is built from operation queries don't deliver the type information itself, but by looking up GraphQL schema naively we can get each of field types in the operation queries. 

However, that would not working as expected if were using union/interface in queries thanks to that it decides the type information in runtime. So for the future support of union/interface, I decided to design type inference which uses `__typename`. We can add some fallback mechanism to look up types in GQL schema for the case that a query does not have `__typename`, but now it is not the right time to do that.

## Reference

https://medium.com/nerd-for-tech/what-is-typename-in-graphql-and-why-is-it-significant-cf334515dbf7