### PR TITLE
Fix cover image path

### DIFF
--- a/packages/fabrix/README.md
+++ b/packages/fabrix/README.md
@@ -1,4 +1,4 @@
-![cover](../../assets/cover.png)
+![cover](https://github.com/fabrix-framework/.github/blob/main/assets/cover.png)
 
 # fabrix <!-- omit in toc -->
 


### PR DESCRIPTION
Cover image has been moved to `.github` repo in this org.