### PR TITLE
Add `publish` property to changesets/action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release Candidate
+name: Release
 
 on:
   push:
@@ -27,5 +27,7 @@ jobs:
           node-version-file: './package.json'
       - run: pnpm install
       - uses: changesets/action@v1
+        with:
+          publish: pnpm changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
-    "type-check": "turbo type-check"
+    "type-check": "turbo type-check",
+    "changeset:publish": "changeset publish"
   },
   "packageManager": "pnpm@9.9.0",
   "devDependencies": {


### PR DESCRIPTION
The release workflow ran at the last time did not publish npm packages, so I have manually published packages from my local instead.

To fix that, I found that changesets/action requires `publish` property to specify a command to publish packages to some registries (ref: https://github.com/changesets/action/blob/main/src/index.ts#L53). It also enables the automated creation of Github releases as well.

This PR adds a script command to call `changeset publish` which is used as `publish` property in the `changesets/action` action to make everything work.

