### PR TITLE
Build packages before `changeset publish`

### DIFF
--- a/.changeset/late-yaks-deny.md
+++ b/.changeset/late-yaks-deny.md
@@ -1,0 +1,7 @@
+---
+"@fabrix-framework/chakra-ui": minor
+"@fabrix-framework/fabrix": minor
+"@fabrix-framework/graphql-config": minor
+---
+
+Fix build files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,3 +31,4 @@ jobs:
           publish: pnpm changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "type-check": "turbo type-check",
-    "changeset:publish": "pnpm build && changeset publish"
+    "changeset:publish": "changeset publish"
   },
   "packageManager": "pnpm@9.9.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "type-check": "turbo type-check",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "pnpm build && changeset publish"
   },
   "packageManager": "pnpm@9.9.0",
   "devDependencies": {

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -13,6 +13,7 @@
     "dist/**"
   ],
   "scripts": {
+    "prepublishOnly": "pnpm build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "tsup",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",

--- a/packages/fabrix/package.json
+++ b/packages/fabrix/package.json
@@ -17,6 +17,7 @@
     "dist/**"
   ],
   "scripts": {
+    "prepublishOnly": "pnpm build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "tsup",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",

--- a/packages/graphql-config/package.json
+++ b/packages/graphql-config/package.json
@@ -18,6 +18,7 @@
     "dist/**"
   ],
   "scripts": {
+    "prepublishOnly": "pnpm build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "tsup",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",


### PR DESCRIPTION
Before publishing packages through `pnpm changeset:publish`, all packages to be published should be built, but no command is executed before that. This PR adds `pnpm build` before `pnpm changeset:publish`.

Plus, the last version that I have published manually probably did not contain the expected changes (I forgot if I ran `pnpm build` before `pnpm changeset:publish`), so bump up the versions of all published packages in this time to make sure everthing has the latest changes.

