### PR TITLE
Build packages at the root instead of prepublishOnly

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev": "turbo dev",
     "build": "turbo build",
     "type-check": "turbo type-check",
-    "changeset:publish": "changeset publish"
+    "changeset:publish": "pnpm build && changeset publish"
   },
   "packageManager": "pnpm@9.9.0",
   "devDependencies": {

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -13,7 +13,6 @@
     "dist/**"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "tsup",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",

--- a/packages/fabrix/package.json
+++ b/packages/fabrix/package.json
@@ -17,7 +17,6 @@
     "dist/**"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "tsup",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",

--- a/packages/graphql-config/package.json
+++ b/packages/graphql-config/package.json
@@ -18,7 +18,6 @@
     "dist/**"
   ],
   "scripts": {
-    "prepublishOnly": "pnpm build",
     "dev": "NODE_ENV=development tsup --watch",
     "build": "tsup",
     "lint": "eslint '**/*.{ts,tsx}' --ignore-pattern 'dist/*' --max-warnings=0",


### PR DESCRIPTION
This PR reverts the change to use `prepublishOnly`, but naively runs `pnpm build` before `changeset publish` in the `package.json` file.

## Background

#141 added `prepublishOnly` to build packages, but chakra-ui package depends on fabrix in its building process, so failed in the workflow. To fix that, the dependency resolustion should be handled by Turborepo in building packages.
