### PR TITLE
Remove `getOperation` function in children props

### DIFF
--- a/.changeset/quick-teachers-melt.md
+++ b/.changeset/quick-teachers-melt.md
@@ -4,4 +4,4 @@
 
 Remove `getOperation` function from children props in FabrixComponent.
 
-Now `query` prop in `FabrixComponent` supports a single query to get it future compatible with TypedDocumentNode.
+Now `query` prop in `FabrixComponent` supports only a single query to get it future compatible with TypedDocumentNode.

--- a/.changeset/quick-teachers-melt.md
+++ b/.changeset/quick-teachers-melt.md
@@ -1,0 +1,7 @@
+---
+"@fabrix-framework/fabrix": minor
+---
+
+Remove `getOperation` function from children props in FabrixComponent.
+
+Now `query` prop in `FabrixComponent` supports a single query to get it future compatible with TypedDocumentNode.

--- a/examples/vite-todoapp/src/App.tsx
+++ b/examples/vite-todoapp/src/App.tsx
@@ -32,7 +32,11 @@ function App() {
               id
             }
           }
-
+        `}
+      />
+      <FabrixComponent
+        containerClassName={containerClassName}
+        query={gql`
           query todos {
             allTodos
               @fabrixView(

--- a/packages/fabrix/__tests__/componentRegistry.test.tsx
+++ b/packages/fabrix/__tests__/componentRegistry.test.tsx
@@ -136,7 +136,7 @@ describe("getFabrixComponent", () => {
           title: "Custom Table",
         }}
         query={gql`
-          query getUsers {
+          query {
             users {
               collection {
                 id
@@ -149,9 +149,7 @@ describe("getFabrixComponent", () => {
       >
         {({ getComponent }) => {
           return (
-            <div data-testid="component-wrapper">
-              {getComponent("getUsers", "users")}
-            </div>
+            <div data-testid="component-wrapper">{getComponent("users")}</div>
           );
         }}
       </CustomTable>,

--- a/packages/fabrix/__tests__/query.test.tsx
+++ b/packages/fabrix/__tests__/query.test.tsx
@@ -85,20 +85,9 @@ describe("collection", () => {
     ["collection", collectionQuery, undefined],
     ["edges", edgeQuery, undefined],
     [
-      "getOperation",
-      collectionQuery,
-      ({ getOperation }) => getOperation("getUsers"),
-    ],
-    [
-      "getOperation/getComponent",
-      collectionQuery,
-      ({ getOperation }) =>
-        getOperation("getUsers", ({ getComponent }) => getComponent("users")),
-    ],
-    [
       "getComponent",
       collectionQuery,
-      ({ getComponent }) => getComponent("getUsers", "users"),
+      ({ getComponent }) => getComponent("users"),
     ],
   ] satisfies [string, string, FabrixComponentChildrenProps][];
 
@@ -231,23 +220,6 @@ describe("collection", () => {
         expect(headers[0]).toHaveTextContent("操作");
       },
       { components },
-    );
-  });
-
-  it("should be able to access the response data for by an operation", async () => {
-    await testWithUnmount(
-      <FabrixComponent query={`query getUsers { users { size } }`}>
-        {({ getOperation }) =>
-          getOperation<{ users: { size: number } }>("getUsers", ({ data }) => (
-            <div role="result-size">{data.users.size}</div>
-          ))
-        }
-      </FabrixComponent>,
-      async () => {
-        const result = await screen.findByRole("result-size");
-        expect(result).toBeInTheDocument();
-        expect(result).toHaveTextContent(users.length.toString());
-      },
     );
   });
 });

--- a/packages/fabrix/__tests__/query.test.tsx
+++ b/packages/fabrix/__tests__/query.test.tsx
@@ -222,4 +222,28 @@ describe("collection", () => {
       { components },
     );
   });
+
+  it("should be able to access the response data for by an operation", async () => {
+    await testWithUnmount(
+      <FabrixComponent
+        query={`
+          query getUsers {
+            users {
+              size
+            }
+          }
+        `}
+      >
+        {({ data }) => (
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          <div role="result-size">{data.users.size}</div>
+        )}
+      </FabrixComponent>,
+      async () => {
+        const result = await screen.findByRole("result-size");
+        expect(result).toBeInTheDocument();
+        expect(result).toHaveTextContent(users.length.toString());
+      },
+    );
+  });
 });

--- a/packages/fabrix/src/fetcher.ts
+++ b/packages/fabrix/src/fetcher.ts
@@ -4,10 +4,10 @@ import { useClient, useQuery } from "urql";
 export const useDataFetch = (props: {
   query: DocumentNode | string;
   variables?: Record<string, unknown>;
+  pause?: boolean;
 }) => {
   const [{ data, fetching, error }] = useQuery<FabrixComponentData>({
-    query: props.query,
-    variables: props.variables,
+    ...props,
   });
 
   return {

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -1,13 +1,5 @@
-<<<<<<< HEAD
 import { DirectiveNode, DocumentNode, OperationTypeNode, parse } from "graphql";
-import { ReactNode, useCallback, useContext, useMemo } from "react";
-||||||| parent of 8ca3de2 (Remove getOperation function)
-import { DirectiveNode, DocumentNode, OperationTypeNode } from "graphql";
-import { ReactNode, useCallback, useContext, useMemo } from "react";
-=======
-import { DirectiveNode, DocumentNode, OperationTypeNode } from "graphql";
 import { ReactNode, useContext, useMemo } from "react";
->>>>>>> 8ca3de2 (Remove getOperation function)
 import { findDirective, parseDirectiveArguments } from "@directive";
 import { ViewRenderer } from "@renderers/fields";
 import { FormRenderer } from "@renderers/form";
@@ -193,62 +185,12 @@ export type FabrixComponentProps = FabrixComponentCommonProps & {
 
 type FabrixComponentChildrenExtraProps = { key?: string; className?: string };
 
-<<<<<<< HEAD
-type FabrixGetComponentFn = (
-  /**
-   * The name that corresponds to the GQL query.
-   */
-  name: string,
-  extraProps?: FabrixComponentChildrenExtraProps,
-  fieldsRenderer?: FabrixComponentFieldsRenderer,
-) => ReactNode;
-
-export type FabrixGetOperationFn = <
-  T extends Record<string, unknown> = Record<string, unknown>,
->(
-  indexOrName: number | string,
-  renderer?: (props: {
-    data: T;
-    getComponent: FabrixGetComponentFn;
-  }) => ReactNode,
-) => ReactNode;
-
-export type FabrixComponentChildrenProps = {
-||||||| parent of 8ca3de2 (Remove getOperation function)
-type FabrixGetComponentFn = (
-  /**
-   * The name that corresponds to the GQL query.
-   */
-  name: string,
-  extraProps?: FabrixComponentChildrenExtraProps,
-  fieldsRenderer?: FabrixComponentFieldsRenderer,
-) => ReactNode;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type FabrixGetOperationFn<TData = any> = (
-  indexOrName: number | string,
-  renderer?: (props: {
-    data: TData;
-    getComponent: FabrixGetComponentFn;
-  }) => ReactNode,
-) => ReactNode;
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FabrixComponentChildrenProps<TData = any> = {
-=======
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type FabrixComponentChildrenProps<TData = any> = {
->>>>>>> 8ca3de2 (Remove getOperation function)
   /**
    * The data fetched from the query
    */
-<<<<<<< HEAD
-  getOperation: FabrixGetOperationFn;
-||||||| parent of 8ca3de2 (Remove getOperation function)
-  getOperation: FabrixGetOperationFn<TData>;
-=======
   data: TData;
->>>>>>> 8ca3de2 (Remove getOperation function)
 
   /**
    * Get the component by root field name
@@ -332,65 +274,15 @@ export const getComponentRendererFn = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
 >(
-  props: FabrixComponentProps<TData>,
+  props: FabrixComponentProps,
   getComponent: ReturnType<typeof getComponentFn>,
 ) => {
   const context = useContext(FabrixContext);
   const { fieldConfigs } = useFieldConfigs(props.query);
-<<<<<<< HEAD
-  const getOperation: FabrixComponentChildrenProps["getOperation"] =
-    useCallback(
-      (indexOrName, renderer) => {
-        const fieldConfig =
-          typeof indexOrName === "number"
-            ? fieldConfigs[indexOrName]
-            : fieldConfigs.find(({ name }) => name == indexOrName);
-        if (!fieldConfig) {
-          throw new Error(`No operation found for indexOrName: ${indexOrName}`);
-        }
-
-        return (
-          <OperationRenderer
-            key={`fabrix-operation${typeof indexOrName === "number" ? `-${indexOrName}` : ""}-${fieldConfig.name}`}
-            operation={fieldConfig}
-            variables={props.variables}
-            getComponentFn={getComponent}
-            renderer={renderer as Parameters<FabrixGetOperationFn>[1]}
-          />
-        );
-      },
-      [fieldConfigs, props.variables],
-    );
-||||||| parent of 8ca3de2 (Remove getOperation function)
-  const getOperation: FabrixComponentChildrenProps["getOperation"] =
-    useCallback(
-      (indexOrName, renderer) => {
-        const fieldConfig =
-          typeof indexOrName === "number"
-            ? fieldConfigs[indexOrName]
-            : fieldConfigs.find(({ name }) => name == indexOrName);
-        if (!fieldConfig) {
-          throw new Error(`No operation found for indexOrName: ${indexOrName}`);
-        }
-
-        return (
-          <OperationRenderer
-            key={`fabrix-operation${typeof indexOrName === "number" ? `-${indexOrName}` : ""}-${fieldConfig.name}`}
-            operation={fieldConfig}
-            variables={props.variables}
-            getComponentFn={getComponent}
-            renderer={renderer}
-          />
-        );
-      },
-      [fieldConfigs, props.variables],
-    );
-=======
   const fieldConfig = fieldConfigs[0];
   if (!fieldConfig) {
     throw new Error(`No operation found`);
   }
->>>>>>> 8ca3de2 (Remove getOperation function)
 
   return () => {
     const { fetching, error, data } = useDataFetch({

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -185,12 +185,12 @@ export type FabrixComponentProps = FabrixComponentCommonProps & {
 
 type FabrixComponentChildrenExtraProps = { key?: string; className?: string };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type FabrixComponentChildrenProps<TData = any> = {
+export type FabrixComponentChildrenProps = {
   /**
    * The data fetched from the query
    */
-  data: TData;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any;
 
   /**
    * Get the component by root field name
@@ -270,10 +270,7 @@ export const FabrixComponent = (props: FabrixComponentProps) => {
   return <div className="fabrix wrapper">{renderComponent()}</div>;
 };
 
-export const getComponentRendererFn = <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TData = any,
->(
+export const getComponentRendererFn = (
   props: FabrixComponentProps,
   getComponent: ReturnType<typeof getComponentFn>,
 ) => {
@@ -302,7 +299,7 @@ export const getComponentRendererFn = <
     const component = getComponent(fieldConfig, data, context);
     if (props.children) {
       return props.children({
-        data: data as TData,
+        data,
         getComponent: component,
       });
     }


### PR DESCRIPTION
In order to support `TypedDocumentNode` for #103, this pull request removes the `getOperation` function from children props in `FabrixComponent`.

I have decided on dropping `getOperation` because type-safety is way more important in implementing applications.

## Background

Initial aim for `getOperation` functions is to support multiple operations in one query that `FabrixCompoent` accepts, but that's not compatible in using [TypedDocumentNode](https://github.com/dotansimha/graphql-typed-document-node) which assumes that the query contains only one operation.