### PR TITLE
New children prop design

### DIFF
--- a/.changeset/lemon-seas-trade.md
+++ b/.changeset/lemon-seas-trade.md
@@ -46,11 +46,13 @@ This is useful in the case like the view that has the form to get the search par
 
 ## More customizable, layoutable form 
 
+Here is the complex example to create an update form to show the customizability and layoutability.
+
 ```tsx
 <FabrixComponent 
   query={gql`
-    mutation createTodo($input: CreateTodoInput!) {
-      createTodo(input: $input) {
+    mutation updateTodo($id: ID!, $input: CreateTodoInput!) {
+      updateTodo(id: $id, input: $input) {
         id 
       } 
     } 
@@ -67,6 +69,7 @@ This is useful in the case like the view that has the form to get the search par
        * The data structure should be matched with the variables of query/mutation. 
        */
       defaultValues: {
+        id: "user-id",
         input: {
           name: "John Doe"
         }
@@ -98,6 +101,8 @@ This is useful in the case like the view that has the form to get the search par
   }
 </FabrixComponent>
 ```
+
+Additionally, for more page-by-page customization for the form, `getInput` functions offers more functions in its render props, mostly powered by react-hook-form that fabrix internal uses.
 
 ### Field-level handler
 

--- a/.changeset/lemon-seas-trade.md
+++ b/.changeset/lemon-seas-trade.md
@@ -61,7 +61,17 @@ This is useful in the case like the view that has the form to get the search par
      * `getInput` is a function to render form view which can acess functions to build forms.
      * `Field` and `getAction` are the key functions (see their explanation below)
      */
-    getInput({}, ({ Field, getAction }) => (
+    getInput({
+      /*
+       * If the form is the one to update resource, set `defaultValues` here to prefill the form fields.
+       * The data structure should be matched with the variables of query/mutation. 
+       */
+      defaultValues: {
+        input: {
+          name: "John Doe"
+        }
+      }
+    }, ({ Field, getAction }) => (
       {/*
         * `getAction` is expcted to be passed as an descructive props to `form` element.
         * It is an object that contains `onSubmit` function as a member that kicks off the query execution.

--- a/.changeset/lemon-seas-trade.md
+++ b/.changeset/lemon-seas-trade.md
@@ -154,6 +154,26 @@ const WatchingField = (props: {
 }
 ```
 
-## Backward compatibility
+## Backward incompatibility
 
-TBW
+The previous behaviour of `FabrixComponent` is that only the component for the result was rendered in `Query` and only the form for `Mutation` on the contrary. 
+However, from this relelase, `FabrixComponent` will render both the form and the result of the component regardless of operation type.
+
+If you would like to maintain the previous behaviour, use directives to guide the query render only the specific component that you want.
+
+```tsx
+/*
+ * `@fabrixForm` directive does not 
+ */
+<FabrixComponent 
+  query={gql`
+    mutation updateTodo($id: ID!, $input: CreateTodoInput!) {
+      updateTodo(id: $id, input: $input) @fabrixForm {
+        id 
+      } 
+    } 
+  `}
+/>
+```
+
+`fabrixView` also works for `Query` operation in the same way.

--- a/.changeset/lemon-seas-trade.md
+++ b/.changeset/lemon-seas-trade.md
@@ -1,0 +1,144 @@
+---
+"@fabrix-framework/fabrix": minor
+---
+
+More flexibility to render the view within `FabrixComponent`.
+
+Now, you can use JSX expressions to place form components using the functions passed down through the children props.
+
+## Query with forms 
+
+Before this release, fabrix does not have any way to render forms for `Query` operation, but from this relelase, `Query` operation also is able to render the form along with the result.
+
+This is useful in the case like the view that has the form to get the search parameters for the query.
+
+```tsx
+<FabrixComponent 
+  query={gql`
+    query getTodos($input: GetTodoInput!) {
+      getTodos(input: $input) {
+        edges {
+          node {
+            name
+            priority 
+          }  
+        }
+      }
+    }
+  `}
+>
+  {({ getInput, getOutput }) => (
+     <>
+       {/*
+         * `getInput` renders the all form fields inferred from the variables
+         * The rendered view by `getInput` without render props also has the button to execute the query.
+         */}
+       {getInput()}
+
+       {/*
+         * `getOuput` renders the result of the mutation
+         */}
+       {getOutput("getTodos")}
+     </>
+  )}
+</FabrixComponent>
+```
+
+## More customizable, layoutable form 
+
+```tsx
+<FabrixComponent 
+  query={gql`
+    mutation createTodo($input: CreateTodoInput!) {
+      createTodo(input: $input) {
+        id 
+      } 
+    } 
+  `}
+>
+  {({ getInput }) =>
+    /*
+     * `getInput` is a function to render form view which can acess functions to build forms.
+     * `Field` and `getAction` are the key functions (see their explanation below)
+     */
+    getInput({}, ({ Field, getAction }) => (
+      {/*
+        * `getAction` is expcted to be passed as an descructive props to `form` element.
+        * It is an object that contains `onSubmit` function as a member that kicks off the query execution.
+        */}
+      <form {...getAction()}>
+        {/*
+          * `Field` is a React component that renders the form field  that autotimacally deciding
+          * the corresponding component according to GraphQL type for the path specified in the `name` prop.
+          *
+          * `extraProps` is the prop to carry information to the form field.
+          * In this example, I assume the component that is registered in the component registry
+          * as the form field handles `label` to show it as a text content in the `label` element.
+          *
+          * The props for the `extraProps` should have more variety (e.g., `disabled`, `placeholder`, ...),
+          * but I will work on adding them in other PRs later on.
+          */}
+        <HStack>
+          <Field name="input.name" extraProps={{ label: "Task Name" }} />
+          <Field name="input.priority" extraProps={{ label: "Task Priority" }} />
+        </HStack>
+        <Button type="submit">Add</Button>
+      </form>
+    ))
+  }
+</FabrixComponent>
+```
+
+### Field-level handler
+
+In the case that the field component automatially decided by GraphQL type does not fit the requirement in the form, `getInput` function provides the another customizable point at the field level in the form.
+
+`getField` function returns the value of `UseFormRegisterReturn` in react-hook-form. Users would be able to use the another input component on the spot with this.
+
+```tsx
+<FabrixComponent query={`/* ... */`}>
+  {({ getInput }) =>
+    getInput({}, ({ Field, getAction, getField }) => {
+      <form {...getAction()}>
+        <Field name="input.name" />
+        <Field name="input.priority" />
+        <input {...getField("input.email")} type="text" />
+      </form>
+    }) 
+  }
+</FabrixComponent>
+```
+
+### Form context
+
+The render props of `getInput` function also passes down `formContext` that is the react-hook-form context that the form rendered by `getInput` internally maintains.
+
+This helps users create the flexible form-wide funcionality as they want by lerveraging the functionality of react-hook-form like inter-field interactibity.
+
+```tsx
+import { UseFormReturn } from "react-hook-form";
+
+const Page = () =>
+  <FabrixComponent query={`/* ... */`}>
+    {({ getInput }) =>
+      getInput({}, ({ getAction, formContext }) => {
+        <form {...getAction()}>
+          <WatchingField formContext={formContext} />
+        </form>
+      }) 
+    }
+  </FabrixComponent>
+
+const WatchingField = (props: {
+  formContext: UseFormReturn,
+}) => {
+  /*
+   * Watches the value on the form field using `watch` method in the form context of react-hook-form
+   */
+  const status = formContext.watch("input.priority");
+}
+```
+
+## Backward compatibility
+
+TBW

--- a/.changeset/lemon-seas-trade.md
+++ b/.changeset/lemon-seas-trade.md
@@ -2,15 +2,18 @@
 "@fabrix-framework/fabrix": minor
 ---
 
-More flexibility to render the view within `FabrixComponent`.
+This update contains the breaking changes specifically on functions that the children prop in `FabrixComponent` passes down to bring more flexibility in rendering the view.
 
-Now, you can use JSX expressions to place form components using the functions passed down through the children props.
+See [#168](https://github.com/fabrix-framework/fabrix/issues/168) for more about the motivation about this change.
 
-## Query with forms 
+## Input and Output 
 
-Before this release, fabrix does not have any way to render forms for `Query` operation, but from this relelase, `Query` operation also is able to render the form along with the result.
+The newly introduced functions in the children prop is `getInput` and `getOutput`.
 
-This is useful in the case like the view that has the form to get the search parameters for the query.
+* `getInput` is a function that plays a role as a form renderer, and also an accessor of the form context and form field control. Input fields are inferred from variable definitions in the corresponding GraphQL operation.
+* `getOutput` is a function that works as a result renderer (the behaviour of it depends on the component registered in the component registry), and also a direct accessor of the query data. Output fields are inferred from selected fields in the corresponding GraphQL operation.
+
+Here is the example implementation that renders the form to get the search condition for `Query` operation alongside the result component like tables.
 
 ```tsx
 <FabrixComponent 
@@ -37,10 +40,36 @@ This is useful in the case like the view that has the form to get the search par
 
        {/*
          * `getOuput` renders the result of the mutation
+         * This example assumes that `getTodos` is rendered as a table component.
          */}
        {getOutput("getTodos")}
      </>
   )}
+</FabrixComponent>
+```
+
+The important point to mention is that `getOutput` and `getInput` work in the same way both for `Query` and `Mutation` by this update. 
+
+### `data` accessor
+
+With this update, `data` accessor is accessible through `getOuput` function, since the data is tied from the query result (output).
+
+```tsx
+<FabrixComponent 
+  query={gql`
+    query getTodo {
+      getTodo {
+        name
+        priority 
+      }
+    }
+  `}
+>
+  {({ getOutput }) =>
+    getOutput("getTodo", ({ data }) => (
+      <div>Todo name: {data.name}</div>
+    ))
+  }
 </FabrixComponent>
 ```
 

--- a/examples/vite-todoapp/src/App.tsx
+++ b/examples/vite-todoapp/src/App.tsx
@@ -1,4 +1,4 @@
-import { Heading, Stack } from "@chakra-ui/react";
+import { Button, Heading, Stack } from "@chakra-ui/react";
 import { FabrixComponent } from "@fabrix-framework/fabrix";
 import { css } from "@emotion/css";
 import { graphql } from "./graphql";
@@ -22,7 +22,17 @@ function App() {
             }
           }
         `)}
-      />
+      >
+        {({ getInput }) =>
+          getInput({}, ({ Field, getAction }) => (
+            <form {...getAction()}>
+              <Field name="input.name" />
+              <Field name="input.priority" />
+              <Button type="submit">Add</Button>
+            </form>
+          ))
+        }
+      </FabrixComponent>
       <FabrixComponent
         containerClassName={containerClassName}
         query={graphql(`

--- a/packages/chakra-ui/package.json
+++ b/packages/chakra-ui/package.json
@@ -37,11 +37,12 @@
     "chakra-react-select": "^6.0.1",
     "chroma-js": "^3.0.0",
     "create-color": "^2.0.6",
+    "es-toolkit": "^1.30.1",
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@emotion/react": "^11",
     "@chakra-ui/react": "^3",
+    "@emotion/react": "^11",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/chakra-ui/src/components/default/form.tsx
+++ b/packages/chakra-ui/src/components/default/form.tsx
@@ -3,7 +3,7 @@ import {
   FormComponentProps,
   FieldType,
 } from "@fabrix-framework/fabrix";
-import { Text, Input, Stack, Box } from "@chakra-ui/react";
+import { Text, Input, Stack, Box, Button } from "@chakra-ui/react";
 import { Switch } from "@components/ui/switch";
 import { Select } from "chakra-react-select";
 import { useController } from "@fabrix-framework/fabrix/rhf";
@@ -11,12 +11,12 @@ import { get } from "es-toolkit/compat";
 import { LabelledHeading } from "./shared";
 
 export const ChakraForm = (props: FormComponentProps) => {
-  const action = props.getAction();
-
   return (
     <Box className={props.className} rowGap={"20px"}>
-      {props.renderFields()}
-      <button onClick={action.onClick}>Submit</button>
+      <form {...props.getAction()}>
+        {props.renderFields()}
+        <Button type="submit">Submit</Button>
+      </form>
     </Box>
   );
 };

--- a/packages/chakra-ui/src/components/default/form.tsx
+++ b/packages/chakra-ui/src/components/default/form.tsx
@@ -15,12 +15,8 @@ export const ChakraForm = (props: FormComponentProps) => {
 
   return (
     <Box className={props.className} rowGap={"20px"}>
-      {props.children
-        ? props.children
-        : [
-            props.renderFields(),
-            <button onClick={action.onClick}>Submit</button>,
-          ]}
+      {props.renderFields()}
+      <button onClick={action.onClick}>Submit</button>
     </Box>
   );
 };

--- a/packages/chakra-ui/src/components/default/form.tsx
+++ b/packages/chakra-ui/src/components/default/form.tsx
@@ -3,28 +3,24 @@ import {
   FormComponentProps,
   FieldType,
 } from "@fabrix-framework/fabrix";
-import { Text, Input, Stack, Box, Button } from "@chakra-ui/react";
+import { Text, Input, Stack, Box } from "@chakra-ui/react";
 import { Switch } from "@components/ui/switch";
 import { Select } from "chakra-react-select";
 import { useController } from "@fabrix-framework/fabrix/rhf";
+import { get } from "es-toolkit/compat";
 import { LabelledHeading } from "./shared";
 
 export const ChakraForm = (props: FormComponentProps) => {
+  const action = props.getAction();
+
   return (
     <Box className={props.className} rowGap={"20px"}>
-      {props.renderFields()}
-      {props.renderSubmit(({ submit, isSubmitting }) => (
-        <Button
-          className="col-12"
-          colorScheme="blue"
-          marginTop={2}
-          // @ts-expect-error
-          isDisabled={isSubmitting}
-          onClick={() => submit()}
-        >
-          Submit
-        </Button>
-      ))}
+      {props.children
+        ? props.children
+        : [
+            props.renderFields(),
+            <button onClick={action.onClick}>Submit</button>,
+          ]}
     </Box>
   );
 };
@@ -61,7 +57,7 @@ const ErrorField = (props: FormFieldComponentProps) => {
   const { formState } = useController({
     name: props.name,
   });
-  const error = formState.errors[props.name];
+  const error = get(formState.errors, props.name);
 
   return (
     error && (
@@ -157,7 +153,6 @@ const NumberFormField = (props: FormFieldComponentProps) => {
   const { className } = props.attributes;
   const { field } = useController({
     name: props.name,
-    defaultValue: props.value ?? "",
     rules: {
       required: props.isRequired,
     },

--- a/packages/fabrix/__tests__/componentRegistry.test.tsx
+++ b/packages/fabrix/__tests__/componentRegistry.test.tsx
@@ -147,11 +147,9 @@ describe("getFabrixComponent", () => {
           }
         `}
       >
-        {({ getComponent }) => {
-          return (
-            <div data-testid="component-wrapper">{getComponent("users")}</div>
-          );
-        }}
+        {({ getOutput }) => (
+          <div data-testid="component-wrapper">{getOutput("users")}</div>
+        )}
       </CustomTable>,
       async () => {
         const wrapper = await screen.findByTestId("component-wrapper");

--- a/packages/fabrix/__tests__/mocks/handlers.ts
+++ b/packages/fabrix/__tests__/mocks/handlers.ts
@@ -3,72 +3,77 @@ import { buildSchema, graphql as executeGraphql } from "graphql";
 import { ObjMap } from "graphql/jsutils/ObjMap";
 import { users } from "./data";
 
-export const mockSchema = buildSchema(`
-# Relay Node
-interface Node {
-  id: ID!
-}
+export const mockSchema = buildSchema(/* GraphQL */ `
+  # Relay Node
+  interface Node {
+    id: ID!
+  }
 
-# Relay PageInfo
-type PageInfo {
-  hasNextPage: Boolean!
-  hasPreviousPage: Boolean!
-  startCursor: String
-  endCursor: String
-}
+  # Relay PageInfo
+  type PageInfo {
+    hasNextPage: Boolean!
+    hasPreviousPage: Boolean!
+    startCursor: String
+    endCursor: String
+  }
 
-type User implements Node {
-  id: ID!
-  name: String!
-  email: String!
-  age: Int!
-  category: UserCategory!
-  address: UserAddress!
-}
+  type User implements Node {
+    id: ID!
+    name: String!
+    email: String!
+    age: Int!
+    category: UserCategory!
+    address: UserAddress!
+  }
 
-type UsersResult {
-  collection: [User!]!
-  size: Int!
-}
+  type UsersResult {
+    collection: [User!]!
+    size: Int!
+  }
 
-type UserEdge {
-  node: User!
-  cursor: String!
-}
+  type UserEdge {
+    node: User!
+    cursor: String!
+  }
 
-type UsersConnection {
-  edges: [UserEdge!]!
-  pageInfo: PageInfo!
-}
+  type UsersConnection {
+    edges: [UserEdge!]!
+    pageInfo: PageInfo!
+  }
 
-type Query {
-  firstUser: User
-  users: UsersResult
-  userEdges: UsersConnection
-}
+  input UsersQueryInput {
+    query: String
+    first: Int
+  }
 
-type UserAddress {
-  city: String
-  street: String
-  zip: String!
-}
+  type Query {
+    firstUser: User
+    users(input: UsersQueryInput): UsersResult
+    userEdges(input: UsersQueryInput): UsersConnection
+  }
 
-enum UserCategory {
-  ADMIN
-  USER
-}
+  type UserAddress {
+    city: String
+    street: String
+    zip: String!
+  }
 
-input CreateUserInput {
-  id: ID
-  name: String!
-  email: String
-  age: Int!
-  category: UserCategory
-}
+  enum UserCategory {
+    ADMIN
+    USER
+  }
 
-type Mutation {
-  createUser(input: CreateUserInput!): User
-}
+  input CreateUserInput {
+    id: ID
+    name: String!
+    email: String
+    age: Int!
+    category: UserCategory
+  }
+
+  type Mutation {
+    createUser(input: CreateUserInput!): User
+  }
 `);
 
 const resolvers = {

--- a/packages/fabrix/__tests__/mutation.test.tsx
+++ b/packages/fabrix/__tests__/mutation.test.tsx
@@ -24,7 +24,9 @@ describe("mutation", () => {
       },
     );
   });
+});
 
+describe("directive", () => {
   it("should render the form with customized labels", async () => {
     await testWithUnmount(
       <FabrixComponent

--- a/packages/fabrix/__tests__/mutation.test.tsx
+++ b/packages/fabrix/__tests__/mutation.test.tsx
@@ -41,13 +41,13 @@ describe("directive", () => {
       () => {
         expect(
           screen.queryByRole("region", {
-            name: /fabrix-input/,
+            name: /fabrix-component-input/,
           }),
         ).toBeInTheDocument();
 
         expect(
           screen.queryByRole("region", {
-            name: /fabrix-output/,
+            name: /fabrix-component-output/,
           }),
         ).not.toBeInTheDocument();
       },
@@ -93,11 +93,11 @@ describe("children props", () => {
       >
         {({ getInput }) =>
           getInput({}, ({ Field, getAction }) => (
-            <div role="form">
+            <form role="form" {...getAction()}>
               <Field name="input.name" extraProps={{ label: "Name" }} />
               <Field name="input.category" extraProps={{ label: "Category" }} />
-              <button {...getAction()}>Send</button>
-            </div>
+              <button type="submit">Send</button>
+            </form>
           ))
         }
       </FabrixComponent>,

--- a/packages/fabrix/__tests__/mutation.test.tsx
+++ b/packages/fabrix/__tests__/mutation.test.tsx
@@ -27,6 +27,33 @@ describe("mutation", () => {
 });
 
 describe("directive", () => {
+  it("should render only the form when the directive is given", async () => {
+    await testWithUnmount(
+      <FabrixComponent
+        query={`
+          mutation createUser($input: CreateUserInput!) {
+            createUser(input: $input) @fabrixForm {
+              id
+            }
+          }
+        `}
+      />,
+      () => {
+        expect(
+          screen.queryByRole("region", {
+            name: /fabrix-input/,
+          }),
+        ).toBeInTheDocument();
+
+        expect(
+          screen.queryByRole("region", {
+            name: /fabrix-output/,
+          }),
+        ).not.toBeInTheDocument();
+      },
+    );
+  });
+
   it("should render the form with customized labels", async () => {
     await testWithUnmount(
       <FabrixComponent
@@ -47,6 +74,46 @@ describe("directive", () => {
 
         expect(within(form).queryByLabelText("id")).not.toBeInTheDocument();
         expect(within(form).getByLabelText("UserName")).toBeInTheDocument();
+      },
+    );
+  });
+});
+
+describe("children props", () => {
+  it("should render the form with children props", async () => {
+    await testWithUnmount(
+      <FabrixComponent
+        query={`
+          mutation createUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+              id
+            }
+          }
+        `}
+      >
+        {({ getInput }) =>
+          getInput({}, ({ Field, getAction }) => (
+            <div role="form">
+              <Field name="input.name" extraProps={{ label: "Name" }} />
+              <Field name="input.category" extraProps={{ label: "Category" }} />
+              <button {...getAction()}>Send</button>
+            </div>
+          ))
+        }
+      </FabrixComponent>,
+      async () => {
+        const form = await screen.findByRole("form");
+
+        const button = await within(form).findByRole("button");
+        expect(within(button).getByText("Send")).toBeInTheDocument();
+
+        const formFields = await within(form).findAllByRole("group");
+        expect(
+          await within(formFields[0]).findByLabelText("Name"),
+        ).toBeInTheDocument();
+        expect(
+          await within(formFields[1]).findByLabelText("Category"),
+        ).toBeInTheDocument();
       },
     );
   });

--- a/packages/fabrix/__tests__/mutation.test.tsx
+++ b/packages/fabrix/__tests__/mutation.test.tsx
@@ -117,4 +117,52 @@ describe("children props", () => {
       },
     );
   });
+
+  it("should render the form populated with initial values", async () => {
+    await testWithUnmount(
+      <FabrixComponent
+        query={`
+          mutation createUser($input: CreateUserInput!) {
+            createUser(input: $input) {
+              id
+            }
+          }
+        `}
+      >
+        {({ getInput }) =>
+          getInput(
+            {
+              defaultValues: {
+                input: {
+                  name: "John Doe",
+                  category: "ADMIN",
+                },
+              },
+            },
+            ({ Field, getAction }) => (
+              <form role="form" {...getAction()}>
+                <Field name="input.name" extraProps={{ label: "Name" }} />
+                <Field
+                  name="input.category"
+                  extraProps={{ label: "Category" }}
+                />
+                <button type="submit">Send</button>
+              </form>
+            ),
+          )
+        }
+      </FabrixComponent>,
+      async () => {
+        const form = await screen.findByRole("form");
+        const formFields = await within(form).findAllByRole("group");
+
+        expect(await within(formFields[0]).findByLabelText("Name")).toHaveValue(
+          "John Doe",
+        );
+        expect(
+          await within(formFields[1]).findByLabelText("Category"),
+        ).toHaveValue("ADMIN");
+      },
+    );
+  });
 });

--- a/packages/fabrix/__tests__/mutationWithValidation.test.tsx
+++ b/packages/fabrix/__tests__/mutationWithValidation.test.tsx
@@ -11,7 +11,7 @@ describe("String", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "name", constraint: { minLength: 5, maxLength: 10 } }
+              { field: "input.name", constraint: { minLength: 5, maxLength: 10 } }
             ]) {
               id
             }
@@ -20,23 +20,23 @@ describe("String", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", faker.string.alpha(4));
+        await form.set("input.name", faker.string.alpha(4));
         await form.submit();
-        expect(form.getAlert("name")).toHaveTextContent(
+        expect(form.getAlert("input.name")).toHaveTextContent(
           "must NOT have fewer than 5 characters",
         );
 
-        await form.set("name", faker.string.alpha(5));
+        await form.set("input.name", faker.string.alpha(5));
         await form.submit();
-        expect(form.getAlert("name")).not.toBeInTheDocument();
+        expect(form.getAlert("input.name")).not.toBeInTheDocument();
 
-        await form.set("name", faker.string.alpha(10));
+        await form.set("input.name", faker.string.alpha(10));
         await form.submit();
-        expect(form.getAlert("name")).not.toBeInTheDocument();
+        expect(form.getAlert("input.name")).not.toBeInTheDocument();
 
-        await form.set("name", faker.string.alpha(11));
+        await form.set("input.name", faker.string.alpha(11));
         await form.submit();
-        expect(form.getAlert("name")).toHaveTextContent(
+        expect(form.getAlert("input.name")).toHaveTextContent(
           "must NOT have more than 10 characters",
         );
       },
@@ -49,7 +49,7 @@ describe("String", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "name", constraint: { pattern: "^[a-z]+$" } }
+              { field: "input.name", constraint: { pattern: "^[a-z]+$" } }
             ]) {
               id
             }
@@ -58,15 +58,15 @@ describe("String", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", "John Doe");
+        await form.set("input.name", "John Doe");
         await form.submit();
-        expect(form.getAlert("name")).toHaveTextContent(
+        expect(form.getAlert("input.name")).toHaveTextContent(
           'must match pattern "^[a-z]+$"',
         );
 
-        await form.set("name", "johndoe");
+        await form.set("input.name", "johndoe");
         await form.submit();
-        expect(form.getAlert("name")).not.toBeInTheDocument();
+        expect(form.getAlert("input.name")).not.toBeInTheDocument();
       },
     );
   });
@@ -77,7 +77,7 @@ describe("String", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "email", constraint: { format: "email" } }
+              { field: "input.email", constraint: { format: "email" } }
             ]) {
               id
             }
@@ -86,15 +86,15 @@ describe("String", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("email", "john.doe");
+        await form.set("input.email", "john.doe");
         await form.submit();
-        expect(form.getAlert("email")).toHaveTextContent(
+        expect(form.getAlert("input.email")).toHaveTextContent(
           'must match format "email"',
         );
 
-        await form.set("email", faker.internet.email());
+        await form.set("input.email", faker.internet.email());
         await form.submit();
-        expect(form.getAlert("email")).not.toBeInTheDocument();
+        expect(form.getAlert("input.email")).not.toBeInTheDocument();
       },
     );
   });
@@ -105,7 +105,7 @@ describe("String", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "name", constraint: { oneOf: ["EmployeeA", "EmployeeB"] } }
+              { field: "input.name", constraint: { oneOf: ["EmployeeA", "EmployeeB"] } }
             ]) {
               id
             }
@@ -114,15 +114,15 @@ describe("String", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", "EmployeeX");
+        await form.set("input.name", "EmployeeX");
         await form.submit();
-        expect(form.getAlert("name")).toHaveTextContent(
+        expect(form.getAlert("input.name")).toHaveTextContent(
           "must be equal to one of the allowed value",
         );
 
-        await form.set("name", "EmployeeA");
+        await form.set("input.name", "EmployeeA");
         await form.submit();
-        expect(form.getAlert("name")).not.toBeInTheDocument();
+        expect(form.getAlert("input.name")).not.toBeInTheDocument();
       },
     );
   });
@@ -135,7 +135,7 @@ describe("Int/Float", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "age", constraint: { min: 20, max: 30 } }
+              { field: "input.age", constraint: { min: 20, max: 30 } }
             ]) {
               id
             }
@@ -144,24 +144,24 @@ describe("Int/Float", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", "John Doe");
-        await form.set("category", "ADMIN");
+        await form.set("input.name", "John Doe");
+        await form.set("input.category", "ADMIN");
 
-        await form.set("age", "19");
+        await form.set("input.age", "19");
         await form.submit();
-        expect(form.getAlert("age")).toHaveTextContent("must be >= 20");
+        expect(form.getAlert("input.age")).toHaveTextContent("must be >= 20");
 
-        await form.set("age", "20");
+        await form.set("input.age", "20");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
 
-        await form.set("age", "30");
+        await form.set("input.age", "30");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
 
-        await form.set("age", "31");
+        await form.set("input.age", "31");
         await form.submit();
-        expect(form.getAlert("age")).toHaveTextContent("must be <= 30");
+        expect(form.getAlert("input.age")).toHaveTextContent("must be <= 30");
       },
     );
   });
@@ -172,7 +172,7 @@ describe("Int/Float", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "age", constraint: { exclusiveMin: 20, exclusiveMax: 30 } }
+              { field: "input.age", constraint: { exclusiveMin: 20, exclusiveMax: 30 } }
             ]) {
               id
             }
@@ -181,24 +181,24 @@ describe("Int/Float", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", "John Doe");
-        await form.set("category", "ADMIN");
+        await form.set("input.name", "John Doe");
+        await form.set("input.category", "ADMIN");
 
-        await form.set("age", "20");
+        await form.set("input.age", "20");
         await form.submit();
-        expect(form.getAlert("age")).toHaveTextContent("must be > 20");
+        expect(form.getAlert("input.age")).toHaveTextContent("must be > 20");
 
-        await form.set("age", "21");
+        await form.set("input.age", "21");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
 
-        await form.set("age", "29");
+        await form.set("input.age", "29");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
 
-        await form.set("age", "30");
+        await form.set("input.age", "30");
         await form.submit();
-        expect(form.getAlert("age")).toHaveTextContent("must be < 30");
+        expect(form.getAlert("input.age")).toHaveTextContent("must be < 30");
       },
     );
   });
@@ -209,7 +209,7 @@ describe("Int/Float", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "age", constraint: { multipleOf: 5 } }
+              { field: "input.age", constraint: { multipleOf: 5 } }
             ]) {
               id
             }
@@ -218,15 +218,17 @@ describe("Int/Float", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", "John Doe");
+        await form.set("input.name", "John Doe");
 
-        await form.set("age", "19");
+        await form.set("input.age", "19");
         await form.submit();
-        expect(form.getAlert("age")).toHaveTextContent("must be multiple of 5");
+        expect(form.getAlert("input.age")).toHaveTextContent(
+          "must be multiple of 5",
+        );
 
-        await form.set("age", "20");
+        await form.set("input.age", "20");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
       },
     );
   });
@@ -237,7 +239,7 @@ describe("Int/Float", () => {
         query={`
           mutation createUser($input: CreateUserInput!) {
             createUser(input: $input) @fabrixForm(input: [
-              { field: "age", constraint: { oneOf: [20, 30] } }
+              { field: "input.age", constraint: { oneOf: [20, 30] } }
             ]) {
               id
             }
@@ -246,22 +248,22 @@ describe("Int/Float", () => {
       />,
       async () => {
         const form = await findForm();
-        await form.set("name", "John Doe");
-        await form.set("category", "ADMIN");
+        await form.set("input.name", "John Doe");
+        await form.set("input.category", "ADMIN");
 
-        await form.set("age", "19");
+        await form.set("input.age", "19");
         await form.submit();
-        expect(form.getAlert("age")).toHaveTextContent(
+        expect(form.getAlert("input.age")).toHaveTextContent(
           "must be equal to one of the allowed value",
         );
 
-        await form.set("age", "20");
+        await form.set("input.age", "20");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
 
-        await form.set("age", "30");
+        await form.set("input.age", "30");
         await form.submit();
-        expect(form.getAlert("age")).not.toBeInTheDocument();
+        expect(form.getAlert("input.age")).not.toBeInTheDocument();
       },
     );
   });

--- a/packages/fabrix/__tests__/query.test.tsx
+++ b/packages/fabrix/__tests__/query.test.tsx
@@ -25,8 +25,12 @@ describe("query", () => {
         `}
       />,
       async () => {
-        const fields = await screen.findAllByRole("region");
-        const textContents = fields.map((field) => field.textContent);
+        const output = await screen.findByRole("region", {
+          name: /fabrix-output/,
+        });
+        const textContents = within(output)
+          .getAllByRole("region")
+          .map((field) => field.textContent);
 
         const user = users[0];
         expect(textContents).toEqual([
@@ -113,6 +117,37 @@ describe("collection", () => {
 });
 
 describe("directive", () => {
+  it("should render only the table when the directive is given", async () => {
+    await testWithUnmount(
+      <FabrixComponent
+        query={`
+          query getUsers {
+            users @fabrixView {
+              collection {
+                id
+                name
+                email
+              }
+            }
+          }
+        `}
+      />,
+      () => {
+        expect(
+          screen.queryByRole("region", {
+            name: /fabrix-input/,
+          }),
+        ).not.toBeInTheDocument();
+
+        expect(
+          screen.queryByRole("region", {
+            name: /fabrix-output/,
+          }),
+        ).toBeInTheDocument();
+      },
+    );
+  });
+
   it("should render the table with customized labels", async () => {
     await testWithUnmount(
       <FabrixComponent
@@ -262,12 +297,11 @@ describe("children props", () => {
         ]);
 
         const form = await screen.findByRole("form");
-        const button = await within(form).findByRole("button");
 
+        const button = await within(form).findByRole("button");
         expect(within(button).getByText("Refetch")).toBeInTheDocument();
 
         const formFields = await within(form).findAllByRole("group");
-
         expect(
           await within(formFields[0]).findByLabelText("First size to get"),
         ).toBeInTheDocument();

--- a/packages/fabrix/__tests__/query.test.tsx
+++ b/packages/fabrix/__tests__/query.test.tsx
@@ -26,7 +26,7 @@ describe("query", () => {
       />,
       async () => {
         const output = await screen.findByRole("region", {
-          name: /fabrix-output/,
+          name: /fabrix-component-output/,
         });
         const textContents = within(output)
           .getAllByRole("region")
@@ -135,13 +135,13 @@ describe("directive", () => {
       () => {
         expect(
           screen.queryByRole("region", {
-            name: /fabrix-input/,
+            name: /fabrix-component-input/,
           }),
         ).not.toBeInTheDocument();
 
         expect(
           screen.queryByRole("region", {
-            name: /fabrix-output/,
+            name: /fabrix-component-output/,
           }),
         ).toBeInTheDocument();
       },
@@ -263,7 +263,7 @@ describe("children props", () => {
         {({ getOutput, getInput }) =>
           getInput({}, ({ getAction, Field }) => (
             <>
-              <div role="form">
+              <form role="form" {...getAction()}>
                 <Field
                   name="input.first"
                   extraProps={{ label: "First size to get" }}
@@ -272,8 +272,8 @@ describe("children props", () => {
                   name="input.query"
                   extraProps={{ label: "Search query" }}
                 />
-                <button {...getAction()}>Refetch</button>
-              </div>
+                <button type="submit">Refetch</button>
+              </form>
               <>
                 <p>User List</p>
                 {getOutput("userEdges")}

--- a/packages/fabrix/__tests__/supports/components.tsx
+++ b/packages/fabrix/__tests__/supports/components.tsx
@@ -61,12 +61,12 @@ const tableView = (props: TableComponentProps) => {
 };
 
 const formView = (props: FormComponentProps) => {
+  const action = props.getAction();
+
   return (
     <div role="form">
       {props.renderFields()}
-      {props.renderSubmit(({ submit }) => (
-        <button onClick={() => submit()}>Submit</button>
-      ))}
+      <button onClick={action.onClick}>Submit</button>
     </div>
   );
 };
@@ -75,8 +75,11 @@ const formFieldView = (props: FormFieldComponentProps) => {
   const { field, formState } = useController({
     name: props.name,
     defaultValue: "",
+    rules: {
+      required: props.isRequired,
+    },
   });
-  const error = formState.errors[props.name];
+  const error = get(formState.errors, props.name);
   const isNumber =
     props.type?.type === "Scalar" &&
     (props.type.name === "Int" || props.type.name === "Float");
@@ -86,7 +89,6 @@ const formFieldView = (props: FormFieldComponentProps) => {
       <label htmlFor={props.name}>{props.attributes.label}</label>
       <input
         {...field}
-        name={props.name}
         id={props.name}
         onChange={(e) => {
           if (e.target.value && isNumber) {

--- a/packages/fabrix/__tests__/supports/components.tsx
+++ b/packages/fabrix/__tests__/supports/components.tsx
@@ -61,13 +61,11 @@ const tableView = (props: TableComponentProps) => {
 };
 
 const formView = (props: FormComponentProps) => {
-  const action = props.getAction();
-
   return (
-    <div role="form">
+    <form role="form" {...props.getAction()}>
       {props.renderFields()}
-      <button onClick={action.onClick}>Submit</button>
-    </div>
+      <button type="submit">Submit</button>
+    </form>
   );
 };
 

--- a/packages/fabrix/package.json
+++ b/packages/fabrix/package.json
@@ -48,6 +48,7 @@
     "es-toolkit": "^1.30.1",
     "graphql-tag": "^2.12.6",
     "react-hook-form": "^7.53.1",
+    "type-fest": "^4.33.0",
     "urql": "^4.2.1",
     "wonka": "^6.3.4",
     "zod": "^3.23.8"

--- a/packages/fabrix/src/fetcher.ts
+++ b/packages/fabrix/src/fetcher.ts
@@ -11,7 +11,7 @@ export const useDataFetch = <
   variables: TVariables | undefined;
   pause?: boolean;
 }) => {
-  const [{ data, fetching, error }] = useQuery<TData>({
+  const [{ data, fetching, error }, executeQuery] = useQuery<TData>({
     query: props.query,
     variables: props.variables as AnyVariables,
     pause: props.pause,
@@ -21,6 +21,7 @@ export const useDataFetch = <
     fetching,
     error,
     data,
+    refetch: executeQuery,
   };
 };
 

--- a/packages/fabrix/src/readers/field.ts
+++ b/packages/fabrix/src/readers/field.ts
@@ -6,7 +6,7 @@ import { deepmerge } from "deepmerge-ts";
 /**
  * Infer the field configuration from the fields
  */
-export const buildDefaultViewFieldConfigs = (fields: Fields) =>
+export const getOutputFields = (fields: Fields) =>
   fields.unwrap().flatMap((field) => {
     const config = viewFieldSchema.parse({
       index: 0,

--- a/packages/fabrix/src/registry.tsx
+++ b/packages/fabrix/src/registry.tsx
@@ -1,5 +1,5 @@
 import { ComponentType } from "react";
-import { FabrixComponentProps } from "@renderer";
+import { FabrixComponentProps, GetInputFieldsRendererProps } from "@renderer";
 import { ViewFieldSchema } from "@directive/schema";
 import { FieldType } from "@renderers/typename";
 import { FabrixCustomComponent } from "@customRenderer";
@@ -68,15 +68,8 @@ export type FormComponentProps<P = unknown> = CustomProps<P> & {
   name: string;
   className?: string;
   renderFields: () => React.ReactNode;
-  renderSubmit: (
-    renderer: (props: {
-      submit: () => void;
-      isSubmitting: boolean;
-    }) => React.ReactElement,
-  ) => React.ReactNode;
-  renderReset: (
-    renderer: (props: { reset: () => void }) => React.ReactNode,
-  ) => React.ReactNode;
+  renderField: (name: string) => React.ReactNode;
+  getAction: GetInputFieldsRendererProps["getAction"];
 };
 
 export type TableComponentHeader = Field & {

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -1,14 +1,27 @@
 import { DirectiveNode, DocumentNode, OperationTypeNode } from "graphql";
-import { ReactNode, useContext, useMemo } from "react";
+import React, { ReactNode, useContext, useMemo } from "react";
 import { findDirective, parseDirectiveArguments } from "@directive";
 import { ViewRenderer } from "@renderers/fields";
 import { FormRenderer } from "@renderers/form";
 import { FabrixContext, FabrixContextType } from "@context";
-import { FabrixComponentFieldsRenderer, Loader } from "@renderers/shared";
 import { directiveSchemaMap } from "@directive/schema";
 import { mergeFieldConfigs } from "@readers/shared";
-import { buildDefaultViewFieldConfigs, viewFieldMerger } from "@readers/field";
-import { buildDefaultFormFieldConfigs, formFieldMerger } from "@readers/form";
+import { getOutputFields, viewFieldMerger } from "@readers/field";
+import { formFieldMerger, getInputFields } from "@readers/form";
+import { AnyVariables, OperationResult, useMutation } from "urql";
+import {
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  FormState,
+  Path,
+  useForm,
+  UseFormRegisterReturn,
+  UseFormReturn,
+} from "react-hook-form";
+import { DirectiveAttributes } from "@registry";
+import { ajvResolver } from "@renderers/form/ajvResolver";
+import { buildAjvSchema } from "@renderers/form/validation";
 import {
   buildRootDocument,
   FieldVariables,
@@ -23,6 +36,14 @@ const decideStrategy = (
 ) => {
   const directive = findDirective(directiveNodes);
   const emptyDirective = { arguments: null } as const;
+
+  if (directive === null) {
+    return {
+      type: "generic",
+      documentType: opType,
+      directive: emptyDirective,
+    };
+  }
 
   switch (opType) {
     case OperationTypeNode.QUERY: {
@@ -56,6 +77,7 @@ const getFieldConfig = (
   opType: OperationTypeNode,
 ) => {
   const strategy = decideStrategy(field.value.directives, opType);
+
   switch (strategy?.type) {
     case "view": {
       const directive = parseDirectiveArguments(
@@ -67,8 +89,9 @@ const getFieldConfig = (
         name: field.getName(),
         type: strategy.type,
         configs: {
-          fields: mergeFieldConfigs(
-            buildDefaultViewFieldConfigs(childFields),
+          inputFields: [],
+          outputFields: mergeFieldConfigs(
+            getOutputFields(childFields),
             directive.input,
             viewFieldMerger,
           ),
@@ -85,11 +108,23 @@ const getFieldConfig = (
         name: field.getName(),
         type: strategy.type,
         configs: {
-          fields: mergeFieldConfigs(
-            buildDefaultFormFieldConfigs(context, fieldVariables),
+          inputFields: [],
+          outputFields: mergeFieldConfigs(
+            getInputFields(context, fieldVariables),
             directive.input,
             formFieldMerger,
           ),
+        },
+      };
+    }
+    case "generic": {
+      return {
+        name: field.getName(),
+        type: strategy.type,
+        configs: {
+          documentType: strategy.documentType,
+          inputFields: getInputFields(context, fieldVariables),
+          outputFields: getOutputFields(childFields),
         },
       };
     }
@@ -102,14 +137,14 @@ const getFieldConfig = (
 export type FieldConfig = ReturnType<typeof getFieldConfig> & {
   document: DocumentNode;
 };
-export type FieldConfigs = {
+export type Operation = {
   name: string;
   document: DocumentNode;
   type: OperationTypeNode;
   fields: FieldConfig[];
 };
 
-export const useFieldConfigs = <
+export const useOperation = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -119,12 +154,12 @@ export const useFieldConfigs = <
 ) => {
   const rootDocument = buildRootDocument(query);
   const context = useContext(FabrixContext);
-  const fieldConfigs = useMemo(() => {
+  const operations = useMemo(() => {
     return rootDocument.map(({ name, document, fields, opType, variables }) =>
       fields
         .unwrap()
         .filter((f) => !f.getParentName())
-        .reduce<FieldConfigs>(
+        .reduce<Operation>(
           (acc, field) => {
             const fieldConfig = getFieldConfig(
               context,
@@ -148,7 +183,7 @@ export const useFieldConfigs = <
     );
   }, [rootDocument, context]);
 
-  return { fieldConfigs };
+  return { operations };
 };
 
 type FabrixComponentCommonProps<
@@ -179,8 +214,7 @@ type FabrixComponentCommonProps<
 export type FabrixComponentProps<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TVariables = Record<string, any>,
+  TVariables extends AnyVariables = AnyVariables,
 > = FabrixComponentCommonProps<TVariables> & {
   /**
    * The query to render.
@@ -197,38 +231,205 @@ export type FabrixComponentProps<
    */
   query: GeneralDocumentType<TData, TVariables>;
 
-  children?: (props: FabrixComponentChildrenProps<TData>) => ReactNode;
+  /**
+   * The children to render the query
+   */
+  children?: (
+    props: FabrixComponentChildrenProps<TData, TVariables>,
+  ) => ReactNode;
 };
 
-type FabrixComponentChildrenExtraProps = { key?: string; className?: string };
+export type RootFieldName<TData> =
+  TData extends Record<string, unknown>
+    ? Exclude<Extract<keyof TData, string>, "__typename">
+    : string;
 
-export type FabrixComponentChildrenProps<
+export type ChildComponentsExtraProps = Partial<DirectiveAttributes> & {
+  key?: string;
+};
+export type GetInputExtraProps = ChildComponentsExtraProps;
+export type GetOutputExtraProps = ChildComponentsExtraProps;
+
+export type GetInputFieldsRendererProps<
+  TVariables extends AnyVariables = AnyVariables,
+> = {
+  /**
+   * Direct access to the control object from react-hook-form
+   */
+  formContext: UseFormReturn<
+    TVariables extends FieldValues ? TVariables : Record<string, unknown>
+  >;
+
+  /**
+   * Get the field by name
+   *
+   * @example
+   * ```tsx
+   * <FabrixComponent query={appQuery}>
+   *   {({ getComponent }) => (
+   *     <>
+   *       {getComponent("getEmployee", {}, ({ getField }) => (
+   *         <>
+   *           {getField("displayName")}
+   *           {getField("email")}
+   *         </>
+   *       ))}
+   *     </>
+   *   )}
+   * </FabrixComponent>
+   * ```
+   */
+  getField: (
+    /**
+     * The name of the field
+     */
+    name: Path<TVariables extends FieldValues ? TVariables : FieldValues>,
+    extraProps?: GetInputExtraProps,
+  ) => UseFormRegisterReturn;
+
+  /**
+   * Get the field component by name
+   *
+   * @example
+   * ```tsx
+   * <FabrixComponent query={appQuery}>
+   *   {({ getInput }) => (
+   *     getInput({}, ({ Field }) => (
+   *       <Field name="displayName" />
+   *       <Field name="email" />
+   *     ))
+   *   )}
+   * </FabrixComponent>
+   * ```
+   */
+  Field: (props: {
+    name: Path<TVariables extends FieldValues ? TVariables : FieldValues>;
+    extraProps?: GetInputExtraProps;
+  }) => React.ReactNode;
+
+  /**
+   * Get the action handler for the query
+   *
+   * @example
+   * ```tsx
+   * <FabrixComponent query={appQuery}>
+   *   {({ getInput }) => (
+   *     getInput({}, ({ getAction, Field }) => (
+   *       <Field name="input.name" />
+   *       <Field name="input.email" />
+   *       <Button {...getAction()}>Submit</Button>
+   *     ))
+   *   )}
+   * </FabrixComponent>
+   * ```
+   */
+  getAction: () => {
+    getState: () => FormState<
+      TVariables extends FieldValues ? TVariables : FieldValues
+    >;
+    onClick: () => Promise<void>;
+  };
+};
+export type GetInputFieldsRenderer<
+  TVariables extends AnyVariables = AnyVariables,
+> = (props: GetInputFieldsRendererProps<TVariables>) => ReactNode;
+
+export type GetInputFn<TVariables extends AnyVariables = AnyVariables> = (
+  extraProps?: GetInputExtraProps,
+  fieldsRenderer?: GetInputFieldsRenderer<TVariables>,
+) => React.ReactNode;
+
+/*
+ * An utility type to get the data right under the root field
+ */
+type DataAtTheRoot<TData> =
+  TData extends Record<string, unknown>
+    ? TData[RootFieldName<TData>]
+    : Record<string, unknown>;
+
+type FieldPathsWithoutTypename<T> = Exclude<
+  FieldPath<
+    NonNullable<T> extends FieldValues
+      ? NonNullable<T>
+      : Record<string, unknown>
+  >,
+  "__typename"
+>;
+
+export type GetOutputFieldsRendererProps<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
 > = {
   /**
    * The data fetched from the query
    */
-  data: TData;
+  data: DataAtTheRoot<TData>;
+
+  /**
+   * Get the field component by name
+   *
+   * @example
+   * ```tsx
+   * <FabrixComponent query={appQuery}>
+   *   {({ getInput }) => (
+   *     getInput({}, ({ Field }) => (
+   *       <Field name="displayName" />
+   *       <Field name="email" />
+   *     ))
+   *   )}
+   * </FabrixComponent>
+   * ```
+   */
+  Field: (props: {
+    name: FieldPathsWithoutTypename<DataAtTheRoot<TData>>;
+    extraProps?: GetOutputExtraProps;
+  }) => React.ReactNode;
+};
+
+export type GetOutputFieldsRenderer<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+> = (props: GetOutputFieldsRendererProps<TData>) => React.ReactNode;
+
+export type GetOutputFn<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+> = (
+  rootFieldName: RootFieldName<TData>,
+  extraProps?: GetOutputExtraProps,
+  fieldsRenderer?: GetOutputFieldsRenderer<TData>,
+) => React.ReactNode;
+
+export type FabrixComponentChildrenProps<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+  TVariables extends AnyVariables = AnyVariables,
+> = {
+  /**
+   * Get the input component by the variable name
+   *
+   * ```tsx
+   * <FabrixComponent query={getUsersQuery}>
+   *   {({ getInput }) => (
+   *     {getInput("input")}
+   *   )}
+   * </FabrixComponent>
+   * ```
+   */
+  getInput: GetInputFn<TVariables>;
 
   /**
    * Get the component by root field name
    *
    * ```tsx
    * <FabrixComponent query={getUsersQuery}>
-   *   {({ getComponent }) => (
-   *     {getComponent("users")}
+   *   {({ getOutput }) => (
+   *     {getInput("users")}
    *   )}
    * </FabrixComponent>
    * ```
    */
-  getComponent: (
-    rootFieldName: TData extends Record<string, unknown>
-      ? Exclude<Extract<keyof TData, string>, "__typename">
-      : string,
-    extraProps?: FabrixComponentChildrenExtraProps,
-    fieldsRenderer?: FabrixComponentFieldsRenderer,
-  ) => ReactNode;
+  getOutput: GetOutputFn<TData>;
 };
 
 /**
@@ -256,135 +457,301 @@ export type FabrixComponentChildrenProps<
 export const FabrixComponent = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TVariables = Record<string, any>,
+  TVariables extends AnyVariables = AnyVariables,
 >(
   props: FabrixComponentProps<TData, TVariables>,
 ) => {
-  const renderComponent = getComponentRendererFn(
-    props,
-    getComponentFn(
-      props,
-      (
-        field: FieldConfig,
-        data: Value,
-        context: FabrixContextType,
-        componentFieldsRenderer?: FabrixComponentFieldsRenderer,
-      ) => {
-        const commonProps = {
-          context,
-          rootField: {
-            name: field.name,
-            fields: field.configs.fields,
-            data,
-            document: field.document,
-            className: props.contentClassName,
-            componentFieldsRenderer,
-          },
-        };
-        switch (field.type) {
-          case "view":
-            return <ViewRenderer {...commonProps} />;
-          case "form": {
-            return <FormRenderer {...commonProps} />;
-          }
-          default:
-            return null;
-        }
+  const buildCommonProps = ({
+    field,
+    fetching,
+    error,
+  }: RendererFnCommonProps) => {
+    return {
+      fetching,
+      error,
+      rootField: {
+        name: field.name,
+        fields: field.configs.outputFields,
+        document: field.document,
+        className: props.contentClassName,
       },
-    ),
-  );
+    };
+  };
 
-  return <div className="fabrix wrapper">{renderComponent()}</div>;
+  const context = useContext(FabrixContext);
+  const { operations } = useOperation(props.query);
+  const operation = operations[0];
+  if (!operation) {
+    throw new Error(`No operation found`);
+  }
+
+  return (
+    <div className={`fabrix-wrapper ${props.containerClassName ?? ""}`}>
+      {getComponentRendererFn(props, operation, (field: FieldConfig) => {
+        switch (field.type) {
+          case "form": {
+            return {
+              getInputComponent: getInputComponentFn((rendererFnProps) => (
+                <FormRenderer
+                  {...buildCommonProps(rendererFnProps)}
+                  context={context}
+                  executeQuery={rendererFnProps.executeQuery}
+                  fieldsRenderer={rendererFnProps.fieldsRenderer}
+                />
+              )),
+              getOutputComponent: getOutputComponentFn(() => void 0),
+            };
+          }
+
+          case "view": {
+            return {
+              getInputComponent: getInputComponentFn(() => void 0),
+              getOutputComponent: getOutputComponentFn((rendererFnProps) => (
+                <ViewRenderer
+                  {...buildCommonProps(rendererFnProps)}
+                  context={context}
+                  data={rendererFnProps.data}
+                  fieldsRenderer={rendererFnProps.fieldsRenderer}
+                />
+              )),
+            };
+          }
+
+          case "generic": {
+            return {
+              getInputComponent: getInputComponentFn((rendererFnProps) => {
+                const commonProps = buildCommonProps(rendererFnProps);
+
+                return (
+                  <FormRenderer
+                    {...{
+                      ...commonProps,
+                      rootField: {
+                        ...commonProps.rootField,
+                        fields: rendererFnProps.field.configs.inputFields,
+                      },
+                    }}
+                    context={context}
+                    executeQuery={rendererFnProps.executeQuery}
+                    fieldsRenderer={rendererFnProps.fieldsRenderer}
+                  />
+                );
+              }),
+              getOutputComponent: getOutputComponentFn((rendererFnProps) => (
+                <ViewRenderer
+                  {...buildCommonProps(rendererFnProps)}
+                  context={context}
+                  data={rendererFnProps.data}
+                  fieldsRenderer={rendererFnProps.fieldsRenderer}
+                />
+              )),
+            };
+          }
+        }
+      })()}
+    </div>
+  );
 };
 
 export const getComponentRendererFn = <
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TData = any,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TVariables = Record<string, any>,
+  TVariables extends AnyVariables = AnyVariables,
 >(
   props: FabrixComponentProps<TData, TVariables>,
-  getComponent: ReturnType<typeof getComponentFn>,
+  operation: Operation,
+  componentsResolver: (field: FieldConfig) => {
+    getInputComponent: ReturnType<
+      typeof getInputComponentFn<TData, TVariables>
+    >;
+    getOutputComponent: ReturnType<typeof getOutputComponentFn<TData>>;
+  },
 ) => {
-  const context = useContext(FabrixContext);
-  const { fieldConfigs } = useFieldConfigs(props.query);
-  const fieldConfig = fieldConfigs[0];
-  if (!fieldConfig) {
-    throw new Error(`No operation found`);
+  const initialField = operation.fields[0];
+  if (!initialField) {
+    throw new Error(`No field found`);
   }
 
   return () => {
-    const { fetching, error, data } = useDataFetch<TData, TVariables>({
-      query: fieldConfig.document,
+    const dataFetch = useDataFetch<TData, TVariables>({
+      query: operation.document,
       variables: props.variables,
-      pause: fieldConfig.type !== OperationTypeNode.QUERY,
+      pause: operation.type !== OperationTypeNode.QUERY,
     });
 
-    if (fetching) {
-      return <Loader />;
-    }
+    const [mutationResult, runMutation] = useMutation<TData, TVariables>(
+      operation.document,
+    );
+    const executeQuery = (input: Record<string, unknown>) => {
+      if (operation.type === OperationTypeNode.QUERY) {
+        return Promise.resolve(
+          dataFetch.refetch({
+            requestPolicy: "network-only",
+          }),
+        );
+      } else if (operation.type === OperationTypeNode.MUTATION) {
+        return runMutation(input as TVariables);
+      }
 
-    if (error) {
-      throw error;
-    }
+      return Promise.resolve();
+    };
 
-    const component = getComponent(fieldConfig, data ?? {}, context);
+    const resolvedComponents = componentsResolver(initialField);
+    const outputComponent = resolvedComponents.getOutputComponent(operation, {
+      fetching: dataFetch.fetching,
+      error: dataFetch.error,
+      data: dataFetch.data ?? {},
+    });
+    const inputComponent = resolvedComponents.getInputComponent(operation, {
+      fetching: mutationResult.fetching,
+      error: mutationResult.error,
+      executeQueryWithInput: executeQuery,
+    });
+
     if (props.children) {
       return props.children({
-        data: data ?? ({} as TData),
-        getComponent: component,
+        getInput: inputComponent,
+        getOutput: outputComponent,
       });
     }
 
-    return fieldConfig.fields.map((field) =>
-      component(field.name, {
-        key: `fabrix-${fieldConfig.name}-${field.name}`,
-      }),
-    );
+    return operation.fields.map((field) => (
+      <div key={field.name} className="fabrix-component">
+        {inputComponent({
+          key: `fabrix-${operation.name}-input-${field.name}`,
+        })}
+        {outputComponent(field.name as RootFieldName<TData>, {
+          key: `fabrix-${operation.name}-output-${field.name}`,
+        })}
+      </div>
+    ));
   };
 };
 
-type RendererFn = (
-  field: FieldConfig,
-  data: Value,
-  context: FabrixContextType,
-  componentFieldsRenderer?: FabrixComponentFieldsRenderer,
-) => ReactNode;
+type RendererFnCommonProps = {
+  field: FieldConfig;
+  fetching: boolean;
+  error: Error | undefined;
+};
 
-export const getComponentFn =
+type RendererComponentCommonProps = {
+  fetching: boolean;
+  error: Error | undefined;
+};
+
+type OutputComponentRendererFnProps = RendererFnCommonProps & {
+  data: Value;
+  fieldsRenderer?: GetOutputFieldsRenderer;
+};
+type OutputComponentFnProps = RendererComponentCommonProps & {
+  data: FabrixComponentData | undefined;
+};
+
+export type ExecuteQueryResult<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+  TVariables extends AnyVariables = AnyVariables,
+> = Promise<void> | Promise<OperationResult<TData, TVariables>>;
+
+type InputComponentRendererFnProps<
+  TVariables extends AnyVariables = AnyVariables,
+> = RendererFnCommonProps & {
+  executeQuery: () => Promise<void>;
+  fieldsRenderer?: GetInputFieldsRenderer<TVariables>;
+};
+type InputComponentFnProps<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+  TVariables extends AnyVariables = AnyVariables,
+> = RendererComponentCommonProps & {
+  executeQueryWithInput: (
+    input: FieldValues,
+  ) => ExecuteQueryResult<TData, TVariables>;
+};
+
+export const getOutputComponentFn =
   <
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     TData = any,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    TVariables = Record<string, any>,
   >(
-    props: FabrixComponentProps<TData, TVariables>,
-    rendererFn: RendererFn,
+    rendererFn: (props: OutputComponentRendererFnProps) => React.ReactNode,
   ) =>
-  (
-    fieldConfig: FieldConfigs,
-    data: FabrixComponentData | undefined,
-    context: FabrixContextType,
-  ) =>
-  (
-    name: string,
-    extraProps?: FabrixComponentChildrenExtraProps,
-    componentFieldsRenderer?: FabrixComponentFieldsRenderer,
-  ) => {
-    const field = fieldConfig.fields.find((f) => f.name === name);
+  (operation: Operation, componentProps: OutputComponentFnProps) =>
+  (...args: Parameters<GetOutputFn<TData>>): React.ReactNode => {
+    const [name, extraProps, fieldsRenderer] = args;
+    const field = operation.fields.find((f) => f.name === name);
     if (!field) {
       throw new Error(`No root field found for name: ${name}`);
     }
 
-    const dataByName = data ? (name in data ? data[name] : {}) : {};
+    return (
+      <div
+        key={extraProps?.key}
+        className={`fabrix-output-container ${extraProps?.className ?? ""}`}
+      >
+        {rendererFn({
+          field,
+          fetching: componentProps.fetching,
+          error: componentProps.error,
+          data: componentProps.data
+            ? name in componentProps.data
+              ? componentProps.data[name]
+              : {}
+            : {},
+          fieldsRenderer,
+        })}
+      </div>
+    );
+  };
+
+export const getInputComponentFn =
+  <
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    TData = any,
+    TVariables extends AnyVariables = AnyVariables,
+  >(
+    rendererFn: (
+      props: InputComponentRendererFnProps<TVariables>,
+    ) => React.ReactNode,
+  ) =>
+  (
+    operation: Operation,
+    componentProps: InputComponentFnProps<TData, TVariables>,
+  ) =>
+  (...args: Parameters<GetInputFn<TVariables>>): React.ReactNode => {
+    const [extraProps, fieldsRenderer] = args;
+    const field = operation.fields[0];
+    const buildSchema = () => {
+      if (field.type === "form") {
+        return buildAjvSchema(field.configs.outputFields);
+      } else if (field.type === "generic") {
+        return buildAjvSchema(field.configs.inputFields);
+      } else {
+        return;
+      }
+    };
+    const schema = buildSchema();
+    const formContext = useForm({
+      resolver: schema && ajvResolver(schema),
+    });
 
     return (
       <div
         key={extraProps?.key}
-        className={`fabrix renderer container ${props.containerClassName ?? ""} ${extraProps?.className ?? ""}`}
+        className={`fabrix-input-container ${extraProps?.className ?? ""}`}
       >
-        {rendererFn(field, dataByName, context, componentFieldsRenderer)}
+        <FormProvider {...formContext}>
+          {rendererFn({
+            field,
+            fetching: componentProps.fetching,
+            error: componentProps.error,
+            executeQuery: () =>
+              formContext.handleSubmit(async (data) =>
+                componentProps.executeQueryWithInput(data),
+              )(),
+            fieldsRenderer,
+          })}
+        </FormProvider>
       </div>
     );
   };

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -376,8 +376,8 @@ export type GetOutputFieldsRendererProps<
    * @example
    * ```tsx
    * <FabrixComponent query={appQuery}>
-   *   {({ getInput }) => (
-   *     getInput({}, ({ Field }) => (
+   *   {({ getOutput }) => (
+   *     getOutput("user", ({ Field }) => (
    *       <Field name="displayName" />
    *       <Field name="email" />
    *     ))

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -13,7 +13,6 @@ import {
   FieldPath,
   FieldValues,
   FormProvider,
-  FormState,
   Path,
   useForm,
   UseFormRegisterReturn,

--- a/packages/fabrix/src/renderer.tsx
+++ b/packages/fabrix/src/renderer.tsx
@@ -324,9 +324,6 @@ export type GetInputFieldsRendererProps<
    * ```
    */
   getAction: () => {
-    getState: () => FormState<
-      TVariables extends FieldValues ? TVariables : FieldValues
-    >;
     onClick: () => Promise<void>;
   };
 };

--- a/packages/fabrix/src/renderers/custom/table.tsx
+++ b/packages/fabrix/src/renderers/custom/table.tsx
@@ -4,25 +4,29 @@ import { FabrixComponentProps } from "@renderer";
 import { ComponentRendererProps } from "@customRenderer";
 import { FieldConfigByType } from "@renderers/shared";
 import { getTableMode, renderTableElement } from "@renderers/table";
+import { FabrixContext } from "@context";
+import { useContext } from "react";
 
 export const CustomComponentTableRenderer = (
   props: FabrixComponentProps & {
-    fieldConfig: FieldConfigByType<"view">;
+    fieldConfig: FieldConfigByType<"generic">;
     component: ComponentRendererProps<TableComponentEntry>;
     data: Value;
   },
 ) => {
-  const tableMode = getTableMode(props.fieldConfig.configs.fields);
+  const context = useContext(FabrixContext);
+  const tableMode = getTableMode(props.fieldConfig.configs.outputFields);
   if (!tableMode) {
     throw new Error("Unsupported table mode");
   }
 
   return renderTableElement({
+    context,
     component: props.component.entry.component,
     customProps: props.component.customProps,
     rootField: {
       name: props.fieldConfig.name,
-      fields: props.fieldConfig.configs.fields,
+      fields: props.fieldConfig.configs.outputFields,
       data: props.data,
     },
     tableMode,

--- a/packages/fabrix/src/renderers/fields.tsx
+++ b/packages/fabrix/src/renderers/fields.tsx
@@ -1,7 +1,12 @@
-import { createElement, useCallback, useContext, useMemo } from "react";
-import { FabrixContext } from "@context";
+import { createElement, useMemo } from "react";
+import { FabrixContextType } from "@context";
 import { Value } from "@fetcher";
 import { get } from "es-toolkit/compat";
+import {
+  ChildComponentsExtraProps,
+  GetOutputFieldsRendererProps,
+  RootFieldName,
+} from "@renderer";
 import {
   assertObjectValue,
   buildClassName,
@@ -17,80 +22,114 @@ import {
   TypenameExtractor,
 } from "./typename";
 
-export type ViewFields = FieldConfigByType<"view">["configs"]["fields"];
+export type ViewFields = FieldConfigByType<"view">["configs"]["outputFields"];
 type ViewField = ViewFields[number];
+type ViewRendererProps<
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+> = CommonFabrixComponentRendererProps<ViewFields> & {
+  data: Value | undefined;
+  fieldsRenderer?: (
+    props: GetOutputFieldsRendererProps<TData>,
+  ) => React.ReactNode;
+};
 
-export const ViewRenderer = ({
-  context,
-  rootField,
-  componentFieldsRenderer,
-  className,
-}: CommonFabrixComponentRendererProps<ViewFields>) => {
+export const ViewRenderer = <
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  TData = any,
+>(
+  props: ViewRendererProps<TData>,
+) => {
+  const { context, rootField, fieldsRenderer, className, fetching } = props;
+
   // If the query is the one that can be rendered as a table, we will render the table component instead of the fields.
   const tableType = useMemo(() => getTableMode(rootField.fields), [rootField]);
 
-  const renderFields = useCallback(() => {
-    const schema = context.schemaLoader;
-    if (schema.status === "loading") {
-      return <Loader />;
-    }
+  const schema = context.schemaLoader;
+  if (schema.status === "loading") {
+    return <Loader />;
+  }
 
-    const typenameExtractor = buildTypenameExtractor({
-      targetValue: rootField.data,
-      schemaSet: schema.schemaSet,
+  const typenameExtractor = buildTypenameExtractor({
+    targetValue: props.data,
+    schemaSet: schema.schemaSet,
+  });
+
+  const field = {
+    component: (name: string, extraProps?: ChildComponentsExtraProps) => {
+      const field = getFieldConfigByKey(rootField.fields, name);
+      if (!field) {
+        return null;
+      }
+
+      return renderField({
+        context,
+        data: props.data,
+        extraClassName: extraProps?.className,
+        indexKey: extraProps?.key ?? `${rootField.name}-${name}`,
+        subFields: getSubFields(typenameExtractor, rootField.fields, name),
+        field: {
+          ...field,
+          ...extraProps,
+          config: {
+            ...field.config,
+            ...extraProps,
+          },
+        },
+        fieldType: typenameExtractor.getFieldTypeByPath(field.field),
+      });
+    },
+  };
+
+  const fieldsComponent = rootField.fields
+    .sort((a, b) => (a.config.index ?? 0) - (b.config.index ?? 0))
+    .flatMap((field, fieldIndex) => {
+      const name = field.field.getName();
+      if (name.startsWith("_")) {
+        // Ignore __typename
+        return [];
+      }
+
+      return renderField({
+        context,
+        data: props.data,
+        indexKey: `${rootField.name}-${fieldIndex}`,
+        subFields: getSubFields(typenameExtractor, rootField.fields, name),
+        field,
+        fieldType: typenameExtractor.getFieldTypeByPath(field.field),
+      });
     });
 
-    if (componentFieldsRenderer) {
-      return componentFieldsRenderer({
-        getField: (name, extraProps) => {
-          const field = getFieldConfigByKey(rootField.fields, name);
-          if (!field) {
-            return null;
-          }
+  if (fetching) {
+    return <Loader />;
+  }
 
-          return renderField({
-            rootField,
-            extraClassName: extraProps?.className,
-            indexKey: extraProps?.key ?? `${rootField.name}-${name}`,
-            subFields: getSubFields(typenameExtractor, rootField.fields, name),
-            field: {
-              ...field,
-              ...extraProps,
-            },
-            fieldType: typenameExtractor.getFieldTypeByPath(field.field),
-          });
+  if (fieldsRenderer) {
+    return fieldsRenderer({
+      data: props.data as TData extends Record<string, unknown>
+        ? TData[RootFieldName<TData>]
+        : Record<string, unknown>,
+      Field: ({ name }) => field.component(name),
+    });
+  }
+
+  return tableType !== null ? (
+    <div className={`fabrix fields ${className ?? ""}`}>
+      {renderTable(
+        context,
+        {
+          name: rootField.name,
+          data: props.data,
+          fields: rootField.fields,
         },
-      });
-    }
-
-    const fieldsComponent = rootField.fields
-      .sort((a, b) => (a.config.index ?? 0) - (b.config.index ?? 0))
-      .flatMap((field, fieldIndex) => {
-        const name = field.field.getName();
-        if (name.startsWith("_")) {
-          // Ignore __typename
-          return [];
-        }
-
-        return renderField({
-          rootField,
-          indexKey: `${rootField.name}-${fieldIndex}`,
-          subFields: getSubFields(typenameExtractor, rootField.fields, name),
-          field,
-          fieldType: typenameExtractor.getFieldTypeByPath(field.field),
-        });
-      });
-
-    return (
-      <div className={`fabrix fields col-row ${className ?? ""}`}>
-        {fieldsComponent}
-      </div>
-    );
-  }, [componentFieldsRenderer, rootField, getSubFields]);
-
-  return tableType !== null
-    ? renderTable(context, rootField, tableType)
-    : renderFields();
+        tableType,
+      )}
+    </div>
+  ) : (
+    <div className={`fabrix fields col-row ${className ?? ""}`}>
+      {fieldsComponent}
+    </div>
+  );
 };
 
 /**
@@ -107,7 +146,7 @@ export const getSubFields = (
   fields
     .filter((f) => {
       const parentKey = f.field.getParent()?.asKey();
-      return parentKey === name || parentKey?.startsWith(`${name}.`)
+      return parentKey === name || parentKey?.startsWith(`${name}.`);
     })
     .sort((a, b) => (a.config.index ?? 0) - (b.config.index ?? 0))
     .map((value) => ({
@@ -126,7 +165,8 @@ export type SubField = ReturnType<typeof getSubFields>[number];
 export type SubFields = Array<SubField>;
 
 type RenderFieldProps = {
-  rootField: CommonFabrixComponentRendererProps<ViewFields>["rootField"];
+  context: FabrixContextType;
+  data: Value | undefined;
   indexKey: string;
   field: ViewField;
   fieldType: FieldType;
@@ -134,19 +174,19 @@ type RenderFieldProps = {
   extraClassName?: string;
 };
 const renderField = ({
-  rootField,
+  context,
+  data,
   field,
   fieldType,
   subFields,
   indexKey,
   extraClassName,
 }: RenderFieldProps) => {
-  const context = useContext(FabrixContext);
   if (field.config.hidden) {
     return;
   }
 
-  assertObjectValue(rootField.data);
+  assertObjectValue(data);
 
   const component = context.componentRegistry.getCustomComponent(
     field.config.componentType?.name,
@@ -169,7 +209,7 @@ const renderField = ({
     key: indexKey,
     name,
     path: field.field.value,
-    value: get(rootField.data, name),
+    value: get(data, name),
     type: fieldType,
     subFields: subFields.map((subField) => ({
       key: subField.value.field.getName(),

--- a/packages/fabrix/src/renderers/form.tsx
+++ b/packages/fabrix/src/renderers/form.tsx
@@ -1,4 +1,4 @@
-import { createElement, useCallback } from "react";
+import { createElement, FormEvent, useCallback } from "react";
 import { defaultFieldType } from "@renderers/typename";
 import { FabrixContextType } from "@context";
 import {
@@ -60,7 +60,10 @@ export const FormRenderer = <TVariables extends AnyVariables = AnyVariables>({
 
   const action = {
     handler: {
-      onClick: executeQuery,
+      onSubmit: async (e: FormEvent) => {
+        e.preventDefault();
+        await executeQuery();
+      },
     },
     component: () => <button onClick={() => executeQuery()}>Submit</button>,
   };

--- a/packages/fabrix/src/renderers/form.tsx
+++ b/packages/fabrix/src/renderers/form.tsx
@@ -60,10 +60,6 @@ export const FormRenderer = <TVariables extends AnyVariables = AnyVariables>({
 
   const action = {
     handler: {
-      getState: useCallback(
-        () => formContext.formState,
-        [formContext.formState],
-      ),
       onClick: executeQuery,
     },
     component: () => <button onClick={() => executeQuery()}>Submit</button>,

--- a/packages/fabrix/src/renderers/form/validation.ts
+++ b/packages/fabrix/src/renderers/form/validation.ts
@@ -1,4 +1,4 @@
-import { FormField, FormFields } from "@renderers/form";
+import { FormField, ViewFields } from "@renderers/form";
 import { JSONSchemaType } from "ajv";
 
 const convertToAjvProperty = (field: FormField) => {
@@ -51,7 +51,7 @@ type SchemaType = {
   additionalProperties: true;
 };
 
-export const buildAjvSchema = (fields: FormFields) => {
+export const buildAjvSchema = (fields: ViewFields) => {
   const schema: SchemaType = {
     type: "object",
     properties: {},
@@ -61,7 +61,7 @@ export const buildAjvSchema = (fields: FormFields) => {
 
   fields.forEach((field) => {
     const path = field.field.asKey().split(".");
-    const current = path.slice(0, -1).reduce<SchemaType>((acc, key) => {
+    const current = path.slice(0, -1).reduce((acc, key) => {
       if (!acc.properties[key]) {
         acc.properties[key] = {
           type: "object",

--- a/packages/fabrix/src/renderers/shared.tsx
+++ b/packages/fabrix/src/renderers/shared.tsx
@@ -1,40 +1,7 @@
 import { DocumentNode } from "graphql";
-import { DirectiveAttributes } from "@registry";
 import { FabrixContextType } from "@context";
 import { FieldConfigWithMeta } from "@readers/shared";
 import { FieldConfig } from "@renderer";
-import { Value } from "@fetcher";
-
-type FabrixComponentFieldsRendererExtraProps = Partial<DirectiveAttributes> & {
-  key?: string;
-};
-export type FabrixComponentFieldsRenderer = (props: {
-  /**
-   * Get the field by name
-   *
-   * ```tsx
-   * <FabrixComponent query={appQuery}>
-   *   {({ getComponent }) => (
-   *     <>
-   *       {getComponent("getEmployee", {}, ({ getField }) => (
-   *         <>
-   *           {getField("displayName")}
-   *           {getField("email")}
-   *         </>
-   *       ))}
-   *     </>
-   *   )}
-   * </FabrixComponent>
-   * ```
-   */
-  getField: (
-    /**
-     * The name of the field
-     */
-    name: string,
-    extraProps?: FabrixComponentFieldsRendererExtraProps,
-  ) => React.ReactNode;
-}) => React.ReactNode;
 
 export type DocumentResolver = () => string | DocumentNode;
 export type RendererQuery = {
@@ -44,13 +11,13 @@ export type RendererQuery = {
 };
 export type CommonFabrixComponentRendererProps<F> = {
   context: FabrixContextType;
+  fetching: boolean;
+  error: Error | undefined;
   rootField: {
     name: string;
     fields: F;
-    data: Value;
     document: DocumentNode;
   };
-  componentFieldsRenderer?: FabrixComponentFieldsRenderer;
   className?: string;
 };
 

--- a/packages/fabrix/src/renderers/table.tsx
+++ b/packages/fabrix/src/renderers/table.tsx
@@ -1,7 +1,7 @@
-import { FabrixContext, FabrixContextType } from "@context";
+import { FabrixContextType } from "@context";
 import { Value } from "@fetcher";
 import { TableComponentEntry } from "@registry";
-import { useContext, createElement } from "react";
+import { createElement } from "react";
 import { RootField, SubFields, ViewFields, getSubFields } from "./fields";
 import { Loader } from "./shared";
 import { buildTypenameExtractor } from "./typename";
@@ -51,6 +51,7 @@ export const renderTable = (
   }
 
   return renderTableElement({
+    context,
     component,
     customProps: {},
     rootField,
@@ -59,19 +60,19 @@ export const renderTable = (
 };
 
 export const renderTableElement = (props: {
+  context: FabrixContextType;
   component: TableComponentEntry["component"];
   customProps: unknown;
   rootField: RootField;
   tableMode: TableMode;
 }) => {
-  const context = useContext(FabrixContext);
   const { name, data, fields } = props.rootField;
   const rootValue = data;
   if (!rootValue) {
     return;
   }
 
-  const schema = context.schemaLoader;
+  const schema = props.context.schemaLoader;
   if (schema.status === "loading") {
     return <Loader />;
   }
@@ -84,14 +85,12 @@ export const renderTableElement = (props: {
   const { component, tableMode } = props;
   const basePath = tableMode == "standard" ? "collection" : "edges.node";
   const subFields = getSubFields(typenameExtractor, fields, basePath);
-  const element = createElement(component, {
+  return createElement(component, {
     name,
-    headers: buildHeaders(context, subFields, basePath),
+    headers: buildHeaders(props.context, subFields, basePath),
     values: getTableValues(rootValue, tableMode),
     customProps: props.customProps,
   });
-
-  return <div className={"fabrix table"}>{element}</div>;
 };
 
 export const buildHeaders = (

--- a/packages/fabrix/src/renderers/typename.ts
+++ b/packages/fabrix/src/renderers/typename.ts
@@ -3,9 +3,7 @@ import {
   GraphQLEnumType,
   GraphQLList,
   GraphQLNonNull,
-  GraphQLNullableType,
   GraphQLObjectType,
-  GraphQLOutputType,
   GraphQLScalarType,
   GraphQLType,
 } from "graphql";
@@ -199,9 +197,7 @@ export const defaultFieldType = {
   name: "String",
 };
 
-export const resolveFieldType = (
-  field: GraphQLOutputType | GraphQLNullableType,
-): FieldType => {
+export const resolveFieldType = (field: GraphQLType): FieldType => {
   if (field instanceof GraphQLScalarType) {
     return newScalarTypeField(field);
   } else if (field instanceof GraphQLEnumType) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,9 @@ importers:
       react-hook-form:
         specifier: ^7.53.1
         version: 7.54.2(react@19.0.0)
+      type-fest:
+        specifier: ^4.33.0
+        version: 4.33.0
       urql:
         specifier: ^4.2.1
         version: 4.2.1(@urql/core@5.0.6(graphql@16.10.0))(react@19.0.0)
@@ -354,7 +357,7 @@ importers:
         version: 10.0.1(eslint@9.18.0(jiti@2.4.2))
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.31.0(eslint@9.18.0(jiti@2.4.2))
+        version: 2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2))
       typescript:
         specifier: ^5
         version: 5.7.3
@@ -5134,8 +5137,8 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@4.26.1:
-    resolution: {integrity: sha512-yOGpmOAL7CkKe/91I5O3gPICmJNLJ1G4zFYVAsRHg7M64biSnPtRj0WNQt++bRkjYOqjWXrhnUw1utzmVErAdg==}
+  type-fest@4.33.0:
+    resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
     engines: {node: '>=16'}
 
   type-is@1.6.18:
@@ -9269,16 +9272,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.18.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.18.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.19.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(eslint@9.18.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.19.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint@9.18.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -9289,7 +9293,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.18.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint@9.18.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -9300,6 +9304,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.8
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.19.1(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -10288,7 +10294,7 @@ snapshots:
       path-to-regexp: 6.3.0
       picocolors: 1.1.1
       strict-event-emitter: 0.5.1
-      type-fest: 4.26.1
+      type-fest: 4.33.0
       yargs: 17.7.2
     optionalDependencies:
       typescript: 5.7.3
@@ -11311,7 +11317,7 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@4.26.1: {}
+  type-fest@4.33.0: {}
 
   type-is@1.6.18:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       create-color:
         specifier: ^2.0.6
         version: 2.0.6
+      es-toolkit:
+        specifier: ^1.30.1
+        version: 1.31.0
       react:
         specifier: '>=18'
         version: 19.0.0
@@ -5611,8 +5614,8 @@ snapshots:
 
   '@ardatan/relay-compiler@12.0.1(@babel/core@7.26.0)(graphql@16.10.0)':
     dependencies:
-      '@babel/generator': 7.26.3
-      '@babel/parser': 7.26.3
+      '@babel/generator': 7.26.5
+      '@babel/parser': 7.26.7
       '@babel/runtime': 7.26.7
       babel-preset-fbjs: 3.4.0(@babel/core@7.26.0)
       chalk: 4.1.2
@@ -5730,7 +5733,7 @@ snapshots:
 
   '@babel/helper-annotate-as-pure@7.25.9':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.26.7
 
   '@babel/helper-compilation-targets@7.25.9':
     dependencies:
@@ -5748,7 +5751,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.25.9
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
-      '@babel/traverse': 7.26.4
+      '@babel/traverse': 7.26.7
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -5756,7 +5759,7 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.25.9':
     dependencies:
       '@babel/traverse': 7.26.7
-      '@babel/types': 7.26.3
+      '@babel/types': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5785,7 +5788,7 @@ snapshots:
 
   '@babel/helper-optimise-call-expression@7.25.9':
     dependencies:
-      '@babel/types': 7.26.3
+      '@babel/types': 7.26.7
 
   '@babel/helper-plugin-utils@7.25.9': {}
 
@@ -5802,8 +5805,8 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.25.9':
     dependencies:
-      '@babel/traverse': 7.26.4
-      '@babel/types': 7.26.3
+      '@babel/traverse': 7.26.7
+      '@babel/types': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
@@ -5838,7 +5841,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-create-class-features-plugin': 7.25.9(@babel/core@7.26.0)
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
 
@@ -5847,39 +5850,39 @@ snapshots:
       '@babel/compat-data': 7.26.3
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.0)
       '@babel/plugin-transform-parameters': 7.25.9(@babel/core@7.26.0)
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-flow@7.26.0(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-import-assertions@7.26.0(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-arrow-functions@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-block-scoped-functions@7.26.5(@babel/core@7.26.0)':
     dependencies:
@@ -5889,16 +5892,16 @@ snapshots:
   '@babel/plugin-transform-block-scoping@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-classes@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.0)
-      '@babel/traverse': 7.26.4
+      '@babel/traverse': 7.26.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -5906,13 +5909,13 @@ snapshots:
   '@babel/plugin-transform-computed-properties@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/template': 7.25.9
 
   '@babel/plugin-transform-destructuring@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-flow-strip-types@7.26.5(@babel/core@7.26.0)':
     dependencies:
@@ -5923,7 +5926,7 @@ snapshots:
   '@babel/plugin-transform-for-of@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
     transitivePeerDependencies:
       - supports-color
@@ -5932,33 +5935,33 @@ snapshots:
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-compilation-targets': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
-      '@babel/traverse': 7.26.4
+      '@babel/helper-plugin-utils': 7.26.5
+      '@babel/traverse': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-literals@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-member-expression-literals@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-modules-commonjs@7.26.3(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/helper-module-transforms': 7.26.0(@babel/core@7.26.0)
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-object-super@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-replace-supers': 7.26.5(@babel/core@7.26.0)
     transitivePeerDependencies:
       - supports-color
@@ -5966,17 +5969,17 @@ snapshots:
   '@babel/plugin-transform-parameters@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-property-literals@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-react-display-name@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-react-jsx-self@7.25.9(@babel/core@7.26.0)':
     dependencies:
@@ -5993,21 +5996,21 @@ snapshots:
       '@babel/core': 7.26.0
       '@babel/helper-annotate-as-pure': 7.25.9
       '@babel/helper-module-imports': 7.25.9
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.0)
-      '@babel/types': 7.26.3
+      '@babel/types': 7.26.7
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-transform-shorthand-properties@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/plugin-transform-spread@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.25.9
     transitivePeerDependencies:
       - supports-color
@@ -6015,7 +6018,7 @@ snapshots:
   '@babel/plugin-transform-template-literals@7.25.9(@babel/core@7.26.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
 
   '@babel/runtime@7.25.7':
     dependencies:
@@ -6032,8 +6035,8 @@ snapshots:
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.26.3
+      '@babel/parser': 7.26.7
+      '@babel/types': 7.26.7
 
   '@babel/traverse@7.25.6':
     dependencies:
@@ -6655,9 +6658,9 @@ snapshots:
 
   '@graphql-codegen/cli@5.0.4(@babel/core@7.26.0)(@types/node@22.10.5)(enquirer@2.4.1)(graphql@16.10.0)(typescript@5.7.3)':
     dependencies:
-      '@babel/generator': 7.26.3
+      '@babel/generator': 7.26.5
       '@babel/template': 7.25.9
-      '@babel/types': 7.26.3
+      '@babel/types': 7.26.7
       '@graphql-codegen/client-preset': 4.6.0(@babel/core@7.26.0)(graphql@16.10.0)
       '@graphql-codegen/core': 4.0.2(graphql@16.10.0)
       '@graphql-codegen/plugin-helpers': 5.1.0(graphql@16.10.0)
@@ -6704,7 +6707,7 @@ snapshots:
 
   '@graphql-codegen/client-preset@4.6.0(@babel/core@7.26.0)(graphql@16.10.0)':
     dependencies:
-      '@babel/helper-plugin-utils': 7.25.9
+      '@babel/helper-plugin-utils': 7.26.5
       '@babel/template': 7.25.9
       '@graphql-codegen/add': 5.0.3(graphql@16.10.0)
       '@graphql-codegen/gql-tag-operations': 4.0.13(@babel/core@7.26.0)(graphql@16.10.0)
@@ -6964,10 +6967,10 @@ snapshots:
   '@graphql-tools/graphql-tag-pluck@8.3.12(graphql@16.10.0)':
     dependencies:
       '@babel/core': 7.26.0
-      '@babel/parser': 7.26.3
+      '@babel/parser': 7.26.7
       '@babel/plugin-syntax-import-assertions': 7.26.0(@babel/core@7.26.0)
-      '@babel/traverse': 7.26.4
-      '@babel/types': 7.26.3
+      '@babel/traverse': 7.26.7
+      '@babel/types': 7.26.7
       '@graphql-tools/utils': 10.7.2(graphql@16.10.0)
       graphql: 16.10.0
       tslib: 2.8.1


### PR DESCRIPTION
This PR adds new interface for `FabrixComponent` children props to support flexible form styling.

See #168 more about the details of changes included in this PR.

## Changes

[See the changeset in this PR](https://github.com/fabrix-framework/fabrix/blob/new_children_prop_design/.changeset/lemon-seas-trade.md)
