### PR TITLE
Add nested object support in json schema generation

### DIFF
--- a/.changeset/brave-apples-love.md
+++ b/.changeset/brave-apples-love.md
@@ -1,0 +1,5 @@
+---
+"@fabrix-framework/fabrix": minor
+---
+
+Support constraints for nested object field in fabrixForm directive API

--- a/packages/fabrix/src/renderers/form/validation.test.ts
+++ b/packages/fabrix/src/renderers/form/validation.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { Path } from "@visitor/path";
+import { buildAjvSchema } from "./validation";
+
+describe("buildAjvSchema", () => {
+  it("empty input should return an empty schema", () => {
+    expect(buildAjvSchema([])).toEqual({
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: true,
+    });
+  });
+
+  it("should return a schema with a single string field", () => {
+    expect(
+      buildAjvSchema([
+        {
+          field: new Path(["name"]),
+          meta: {
+            fieldType: { type: "Scalar", name: "String" },
+            isRequired: true,
+          },
+          constraint: { minLength: 3, maxLength: 5 },
+          config: {
+            hidden: false,
+            gridCol: 12,
+          },
+        },
+      ]),
+    ).toEqual({
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          minLength: 3,
+          maxLength: 5,
+        },
+      },
+      required: ["name"],
+      additionalProperties: true,
+    });
+  });
+
+  it("should return a valid schema with nested fields (2 level)", () => {
+    expect(
+      buildAjvSchema([
+        {
+          field: new Path(["input", "name"]),
+          meta: {
+            fieldType: { type: "Scalar", name: "String" },
+            isRequired: true,
+          },
+          constraint: { minLength: 3, maxLength: 5 },
+          config: {
+            hidden: false,
+            gridCol: 12,
+          },
+        },
+      ]),
+    ).toEqual({
+      type: "object",
+      properties: {
+        input: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              minLength: 3,
+              maxLength: 5,
+            },
+          },
+          required: ["name"],
+          additionalProperties: true,
+        },
+      },
+      required: [],
+      additionalProperties: true,
+    });
+  });
+
+  it("should return a valid schema with nested fields (3 level)", () => {
+    expect(
+      buildAjvSchema([
+        {
+          field: new Path(["input", "name", "first"]),
+          meta: {
+            fieldType: { type: "Scalar", name: "String" },
+            isRequired: true,
+          },
+          constraint: { minLength: 3, maxLength: 5 },
+          config: {
+            hidden: false,
+            gridCol: 12,
+          },
+        },
+      ]),
+    ).toEqual({
+      type: "object",
+      properties: {
+        input: {
+          type: "object",
+          properties: {
+            name: {
+              type: "object",
+              properties: {
+                first: {
+                  type: "string",
+                  minLength: 3,
+                  maxLength: 5,
+                },
+              },
+              required: ["first"],
+              additionalProperties: true,
+            },
+          },
+          required: [],
+          additionalProperties: true,
+        },
+      },
+      required: [],
+      additionalProperties: true,
+    });
+  });
+});

--- a/packages/fabrix/src/renderers/form/validation.ts
+++ b/packages/fabrix/src/renderers/form/validation.ts
@@ -77,16 +77,9 @@ export const buildAjvSchema = (fields: FormFields) => {
     const property = convertToAjvProperty(field);
 
     if (property !== null) {
-      if (path.length === 1) {
-        schema.properties[lastKey] = property;
-        if (field.meta?.isRequired) {
-          schema.required.push(lastKey);
-        }
-      } else {
-        current.properties[lastKey] = property;
-        if (field.meta?.isRequired) {
-          current.required.push(lastKey);
-        }
+      current.properties[lastKey] = property;
+      if (field.meta?.isRequired) {
+        current.required.push(lastKey);
       }
     }
   });


### PR DESCRIPTION
In #155, fabrix is going to support multiple variables to render forms.

To support that, `fabrixForm` API should accept dot-separated paths to specify configuration by each field in variables, but it does not currently. This PR makes changes on `buildAjvSchema` to make it generate a valid nested object schema.